### PR TITLE
Prefetch Loading. This adds prefetch support. mouseover and touchstart events are tracked shaving off up to a few hundred ms in response reaction.

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -27,12 +27,13 @@ fetchReplacement = (url, prefetch) ->
   usePrefetch = url
   startTime = new Date().getTime()
   if prefetch
+    console.log "Prefetching"
     usePrefetch = null
   else if prefetchTimer
       clearTimeout prefetchTimer
       prefetchTimer = null
 
-  if usePrefetch isnt prefetchCache?.url
+  if url isnt prefetchCache?.url or (prefetch and prefetchCache.url isnt url)
     xhr?.abort()
     xhr = createXhrRequest url, referer
     prefetchCache = {url: url, doc: null}

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -308,11 +308,11 @@ targetLink = (link) ->
 nonStandardClick = (event) ->
   event.which > 1 or event.metaKey or event.ctrlKey or event.shiftKey or event.altKey
 
-dataRemoteLink = (link) ->
-  link.getAttribute('data-remote')
-  
+dataBindLink = (link) ->
+  link.getAttribute('data-remote') or link.getAttribute('data-method') or link.getAttribute('data-confirm')
+
 ignoreClick = (event, link) ->
-  crossOriginLink(link) or anchoredLink(link) or nonHtmlLink(link) or noTurbolink(link) or targetLink(link) or nonStandardClick(event) or dataRemoteLink(link)
+  crossOriginLink(link) or anchoredLink(link) or nonHtmlLink(link) or noTurbolink(link) or targetLink(link) or nonStandardClick(event) or dataBindLink(link)
 
 initializeTurbolinks = ->
   rememberCurrentUrl()

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -308,8 +308,11 @@ targetLink = (link) ->
 nonStandardClick = (event) ->
   event.which > 1 or event.metaKey or event.ctrlKey or event.shiftKey or event.altKey
 
+dataRemoteLink = (link) ->
+  link.getAttribute('data-remote')
+  
 ignoreClick = (event, link) ->
-  crossOriginLink(link) or anchoredLink(link) or nonHtmlLink(link) or noTurbolink(link) or targetLink(link) or nonStandardClick(event)
+  crossOriginLink(link) or anchoredLink(link) or nonHtmlLink(link) or noTurbolink(link) or targetLink(link) or nonStandardClick(event) or dataRemoteLink(link)
 
 initializeTurbolinks = ->
   rememberCurrentUrl()

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -27,13 +27,15 @@ fetchReplacement = (url, prefetch) ->
   usePrefetch = url
   startTime = new Date().getTime()
   if prefetch
-    console.log "Prefetching"
     usePrefetch = null
   else if prefetchTimer
       clearTimeout prefetchTimer
       prefetchTimer = null
 
-  if url isnt prefetchCache?.url or (prefetch and prefetchCache.url isnt url)
+  if prefetch && prefetchCache?.url is url
+    return
+
+  if url isnt prefetchCache?.url
     xhr?.abort()
     xhr = createXhrRequest url, referer
     prefetchCache = {url: url, doc: null}

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -8,7 +8,7 @@ requestMethod  = document.cookie.match(/request_method=(\w+)/)?[1].toUpperCase()
 xhr            = null
 usePrefetch    = false
 prefetchCache  = null
-
+startTime = null
 
 createXhrRequest = (url, sourceUrl) ->
   # Remove hash from url to ensure IE 10 compatibility
@@ -23,6 +23,7 @@ createXhrRequest = (url, sourceUrl) ->
 fetchReplacement = (url, prefetch) ->
   triggerEvent 'page:fetch'
   usePrefetch = url
+  startTime = new Date().getTime()
   if prefetch
     console.log "Prefetching"
     usePrefetch = null
@@ -67,6 +68,8 @@ applyXhrResponse = (url, doc, cachedXhr) ->
     document.location.href = document.location.href
   else
     resetScrollPosition()
+  timeDiff = new Date().getTime() - startTime
+  console.log "Page loaded in #{timeDiff}ms from Click"
   triggerEvent 'page:load'
       
 prefetch = (url) ->
@@ -239,7 +242,7 @@ browserCompatibleDocumentParser = ->
 
 
 installPrefetchMonitor = ->
-  document.addEventListener 'mouseover', handlePrefetch, false
+  document.addEventListener 'mousedown', handlePrefetch, false
   document.addEventListener 'touchstart', handlePrefetch, false
 
 installClickHandlerLast = (event) ->

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -24,6 +24,7 @@ fetchReplacement = (url, prefetch) ->
   triggerEvent 'page:fetch'
   usePrefetch = url
   if prefetch
+    console.log "Prefetching"
     usePrefetch = null
 
   if usePrefetch isnt prefetchCache?.url
@@ -32,8 +33,11 @@ fetchReplacement = (url, prefetch) ->
     prefetchCache = {url: url, doc: null}
     xhr.onload = ->
       if prefetch && usePrefetch isnt url
-        prefetchCache.doc = processResponse()
-        prefetchCache.xhr = xhr
+        if doc = processResponse()
+          prefetchCache.doc = doc
+          prefetchCache.xhr = xhr
+        else
+          prefetchCache = null
       else
         if doc = processResponse()
           usePrefetch = null


### PR DESCRIPTION
This prefetch support will monitor touchstart or mouseover events. If detected an ajax fetch will be called and cached. When the click event occurs if the cache is finished loading it will use it. If not, it will set the state such that the xhr request will process the load as a standard load. Shaving off request delay cycles.