### PR TITLE
Add possibility to keep current scroll position in the Turbolinks.visit API

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,22 @@ You can use `Turbolinks.visit(path)` to go to a URL through Turbolinks.
 
 You can also use `redirect_to path, turbolinks: true` in Rails to perform a redirect via Turbolinks.
 
+Scroll position (3.0+)
+----------------------
+
+By default, `Turbolinks.visit(path)` will reset the scroll position to `(0, 0)`.
+
+You can prevent that by invoking it like `Turbolinks.visit(path, { keepScrollPosition: true })`, or by marking your link or any parent container with the `data-turbolinks-keep-scroll` attribute.
+
+```html
+<a href="/path" data-turbolinks-keep-scroll>Refresh the page and keep the scroll position.</a>
+
+<script type="text/javascript">
+  // Call it manually
+  Turbolinks.visit('/path', { keepScrollPosition: true });
+</script>
+```
+
 Partial replacements with Turbolinks (3.0+)
 -------------------------------------------
 

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -34,7 +34,7 @@ fetch = (url, options = {}) ->
     options.showProgressBar = false
     fetchReplacement url, options
   else
-    options.onLoadFunction = resetScrollPosition
+    options.onLoadFunction = resetScrollPosition unless options.keepScrollPosition
     fetchReplacement url, options
 
 transitionCacheFor = (url) ->
@@ -383,6 +383,13 @@ class Link extends ComponentUrl
     @link = @link.cloneNode false
     super
 
+  keepScrollPosition: ->
+    link = @originalElement
+    until keepScroll or link is document
+      keepScroll = link.getAttribute('data-turbolinks-keep-scroll')?
+      link = link.parentNode
+    keepScroll
+
   shouldIgnore: ->
     @crossOrigin() or
       @_anchored() or
@@ -425,7 +432,7 @@ class Click
     return if @event.defaultPrevented
     @_extractLink()
     if @_validForTurbolinks()
-      visit @link.href unless pageChangePrevented(@link.absolute)
+      visit(@link.href, keepScrollPosition: @link.keepScrollPosition()) unless pageChangePrevented(@link.absolute)
       @event.preventDefault()
 
   _extractLink: ->
@@ -632,7 +639,7 @@ else
   visit = (url) -> document.location.href = url
 
 # Public API
-#   Turbolinks.visit(url)
+#   Turbolinks.visit(url, options)
 #   Turbolinks.replace(html)
 #   Turbolinks.pagesCached()
 #   Turbolinks.pagesCached(20)

--- a/test/keepscroll.html
+++ b/test/keepscroll.html
@@ -46,7 +46,7 @@
   </div>
   <iframe height='1' scrolling='no' src='/offline.html' style='display: none;' width='1'></iframe>
 
-  <p><a href="/keepscroll.html" data-turbolinks-keep-scroll>Dont reset the scroll position</a></p>
+  <p>Scroll position should't have changed<br /><a href="/index.html">Return to index</a></p>
 
   <script type="text/javascript" data-turbolinks-eval=false>
     console.log("turbolinks-eval-false script fired. This should only happen on the initial page load.");


### PR DESCRIPTION
On certain occasions some might need to keep current scroll position.
In my case I call `Turbolinks.visit(location.href)` to reload the content of the current page -- this is an improvised replacement for `location.reload()`.
Problem is, that if you want to reload the current page content for, say, new elements created by AJAX form submission, the page will scroll back to top, yet you want to keep the scroll position.

Partial replacements is a way to do this, but requires specific Rails code on the backend to just render that partial and then you're getting even more tied to the front-end.

So, I've added an extra option to keep the scroll position.

When invoking Turbolinks manually:
```javascript
Turbolinks.visit(path, { keepScrollPosition: true });
```

Or by marking the element with the `data-turbolinks-keep-scroll` attribute:
```html
<a href="/path" data-turbolinks-keep-scroll>Change the page and keep current scroll position.</a>
```

Edited: **2015-05-04**
