### PR TITLE
reflect redirected URL before applying page contents

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -25,8 +25,8 @@ fetchReplacement = (url) ->
 
     if doc = processResponse()
       reflectNewUrl url
-      changePage extractTitleAndBody(doc)...
       reflectRedirectedUrl()
+      changePage extractTitleAndBody(doc)...
       resetScrollPosition()
       triggerEvent 'page:load'
     else

--- a/test/config.ru
+++ b/test/config.ru
@@ -11,6 +11,14 @@ map "/js" do
   run Assets
 end
 
+map "/redirect.html" do
+  run lambda { |env| [302, { "Content-Type" => "text/html", "Location" => "/redirect_target.html" }, []] }
+end
+
+map "/redirect_target.html" do
+  run Rack::File.new(File.expand_path("../redirect_target.html", __FILE__), {"X-XHR-Redirected-To" => "/redirect_target.html"})
+end
+
 map "/500" do
   # throw Internal Server Error (500)
 end

--- a/test/index.html
+++ b/test/index.html
@@ -28,6 +28,7 @@
     <li><a href="/dummy.gif?12345">Query Param Image Link</a></li>
     <li><a href="#">Hash link</a></li>
     <li><a href="/reload.html#foo">New assets track with hash link</a></li>
+    <li><a href="/redirect.html">Follow a redirect and report the correct URL</a></li>
     <li><h5>If you stop the server or go into airplane/offline mode</h5></li>
     <li><a href="/doesnotexist.html">A page with client error (4xx, rfc2616 sec. 10.4) should error out</a></li>
     <li><a href="/500">Also server errors (5xx, rfc2616 sec. 10.5) should error out</a></li>

--- a/test/redirect_target.html
+++ b/test/redirect_target.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Home</title>
+  <script type="text/javascript" src="/js/turbolinks.js"></script>
+  <script type="text/javascript">
+    document.addEventListener("page:change", function() {
+      console.log("page changed");
+    });
+  </script>
+</head>
+<body class="page-reload">
+  This page should log (to the console) its current URL, not the URL of the page that redirected to it.
+  <script type="text/javascript">
+    console.log(window.location.href)
+  </script>
+  <ul>
+    <li><a href="/index.html">Home</a></li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
I've swapped the order of the calls to `changePage` and `reflectRedirectedUrl`. This was causing issues with scripts  called during the `executeScriptTags` reading from `window.location.href` after a redirect. I've added a simple test case which demonstrates this.