### PR TITLE
Integrated header check for redirects via redirect_with_turbolinks to avoid plain body responses on non AJAX requests

### DIFF
--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -53,9 +53,13 @@ module Turbolinks
     def redirect_via_turbolinks_to(url = {}, response_status = {})
       redirect_to(url, response_status)
 
-      self.status           = 200
-      self.response_body    = "Turbolinks.visit('#{location}');"
-      response.content_type = Mime::JS
+      if request.format.include? 'javascript'
+	      self.status           = 200
+	      self.response_body    = "Turbolinks.visit('#{location}');"
+	      response.content_type = Mime::JS
+      else
+	      self.status = 302
+      end
     end
   end
 

--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -53,7 +53,7 @@ module Turbolinks
     def redirect_via_turbolinks_to(url = {}, response_status = {})
       redirect_to(url, response_status)
 
-      if request.format.include? 'javascript'
+      if request.headers['X-Requested-With'].eql? 'XMLHttpRequest'
 	      self.status           = 200
 	      self.response_body    = "Turbolinks.visit('#{location}');"
 	      response.content_type = Mime::JS

--- a/lib/turbolinks/redirection.rb
+++ b/lib/turbolinks/redirection.rb
@@ -11,6 +11,8 @@ module Turbolinks
         self.status = 200
         self.response_body = "Turbolinks.visit('#{location}');"
         response.content_type = Mime::JS
+      else
+        self.status = 302
       end
 
     end

--- a/lib/turbolinks/redirection.rb
+++ b/lib/turbolinks/redirection.rb
@@ -3,13 +3,16 @@ module Turbolinks
   # will respond with a JavaScript call to Turbolinks.visit(url).
   module Redirection
     extend ActiveSupport::Concern
-    
+
     def redirect_via_turbolinks_to(url = {}, response_status = {})
       redirect_to(url, response_status)
 
-      self.status           = 200
-      self.response_body    = "Turbolinks.visit('#{location}');"
-      response.content_type = Mime::JS
+      if request.headers['X-Requested-With'].eql? 'XMLHttpRequest'
+        self.status = 200
+        self.response_body = "Turbolinks.visit('#{location}');"
+        response.content_type = Mime::JS
+      end
+
     end
   end
 end


### PR DESCRIPTION
As we got some troubles with *redirect_via_turbolinks* and plain text responses in some situations, I investigated on the problem and found this short snippet of code that doesn't distinguish between regular http requests and those sent via XMLHttpRequest. 

With my fix, we never experienced a 200 response with *Turbolinks.visit(...)* in the body anymore. All regular non-AJAX requests got redirected perfectly by the browser. AJAX requests get the javascript response and execute the turbo links code.