### PR TITLE
Prevent updating document url to the same url

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -47,7 +47,7 @@ fetchReplacement = (url, onLoadFunction = =>) ->
       reflectRedirectedUrl()
       onLoadFunction()
       triggerEvent 'page:load'
-    else
+    else if document.location.href != url
       document.location.href = url
 
   xhr.onloadend = -> xhr = null


### PR DESCRIPTION
Currently when using pushState in an app, it's possible that turbolinks will update the document url to an identical url, which simply causes an unnecessary refresh of the current page.

This update checks to make sure it's not already set to the correct url before trying to update it.