### PR TITLE
Mechanism to override body replace

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -31,7 +31,7 @@ transitionCacheFor = (url) ->
 enableTransitionCache = (enable = true) ->
   transitionCacheEnabled = enable
 
-fetchReplacement = (url, onLoadFunction = =>) ->  
+fetchReplacement = (url, onLoadFunction = =>) ->
   triggerEvent 'page:fetch', url: url.absolute
 
   xhr?.abort()
@@ -68,7 +68,7 @@ cacheCurrentPage = ->
 
   pageCache[currentStateUrl.absolute] =
     url:                      currentStateUrl.relative,
-    body:                     document.body,
+    body:                     document.body.cloneNode(true),
     title:                    document.title,
     positionY:                window.pageYOffset,
     positionX:                window.pageXOffset,
@@ -237,10 +237,10 @@ browserCompatibleDocumentParser = ->
 
 
 # The ComponentUrl class converts a basic URL string into an object
-# that behaves similarly to document.location.  
+# that behaves similarly to document.location.
 #
-# If an instance is created from a relative URL, the current document 
-# is used to fill in the missing attributes (protocol, host, port).  
+# If an instance is created from a relative URL, the current document
+# is used to fill in the missing attributes (protocol, host, port).
 class ComponentUrl
   constructor: (@original = document.location.href) ->
     return @original if @original.constructor is ComponentUrl
@@ -277,18 +277,18 @@ class Link extends ComponentUrl
     super
 
   shouldIgnore: ->
-    @_crossOrigin() or 
-      @_anchored() or 
-      @_nonHtml() or 
-      @_optOut() or 
+    @_crossOrigin() or
+      @_anchored() or
+      @_nonHtml() or
+      @_optOut() or
       @_target()
 
   _crossOrigin: ->
     @origin isnt (new ComponentUrl).origin
-    
+
   _anchored: ->
-    ((@hash and @withoutHash()) is (current = new ComponentUrl).withoutHash()) or 
-      (@href is current.href + '#') 
+    ((@hash and @withoutHash()) is (current = new ComponentUrl).withoutHash()) or
+      (@href is current.href + '#')
 
   _nonHtml: ->
     @pathname.match(/\.[a-z]+$/g) and not @pathname.match(new RegExp("\\.(?:#{Link.HTML_EXTENSIONS.join('|')})?$", 'g'))
@@ -305,9 +305,9 @@ class Link extends ComponentUrl
 
 
 # The Click class handles clicked links, verifying if Turbolinks should
-# take control by inspecting both the event and the link. If it should, 
-# the page change process is initiated. If not, control is passed back 
-# to the browser for default functionality. 
+# take control by inspecting both the event and the link. If it should,
+# the page change process is initiated. If not, control is passed back
+# to the browser for default functionality.
 class Click
   @installHandlerLast: (event) ->
     unless event.defaultPrevented
@@ -322,7 +322,7 @@ class Click
     @_extractLink()
     if @_validForTurbolinks()
       visit @link.href unless pageChangePrevented()
-      @event.preventDefault() 
+      @event.preventDefault()
 
   _extractLink: ->
     link = @event.target
@@ -333,10 +333,10 @@ class Click
     @link? and not (@link.shouldIgnore() or @_nonStandardClick())
 
   _nonStandardClick: ->
-    @event.which > 1 or 
-      @event.metaKey or 
-      @event.ctrlKey or 
-      @event.shiftKey or 
+    @event.which > 1 or
+      @event.metaKey or
+      @event.ctrlKey or
+      @event.shiftKey or
       @event.altKey
 
 

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -93,7 +93,8 @@ constrainPageCacheTo = (limit) ->
 
 changePage = (title, body, csrfToken, runScripts) ->
   document.title = title
-  document.documentElement.replaceChild body, document.body
+  if triggerEvent 'page:replace', html: body
+    document.documentElement.replaceChild body, document.body
   CSRFToken.update csrfToken if csrfToken?
   executeScriptTags() if runScripts
   currentState = window.history.state

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -93,7 +93,7 @@ constrainPageCacheTo = (limit) ->
 
 changePage = (title, body, csrfToken, runScripts) ->
   document.title = title
-  if triggerEvent 'page:replace', html: body
+  if triggerEvent('page:replace', html: body)
     document.documentElement.replaceChild body, document.body
   CSRFToken.update csrfToken if csrfToken?
   executeScriptTags() if runScripts


### PR DESCRIPTION
This commit keeps the default behaviour but lets you override the default behaviour of replacing the body tag.

Here's an example of me overriding the default behaviour.
```coffee  
$ ->
  $(document).on 'page:replace', (e) ->
    turboElement = document.getElementById 'turbolinks-replace'
    newTurboElement = $(e.originalEvent.data.html).find('#turbolinks-replace')[0]
    turboElement.parentElement.replaceChild newTurboElement, turboElement  
    false #cancel default turbo link replace
```

I've got a long running video background I don't want reloaded every page replace.

https://github.com/rails/turbolinks/pull/204, I also ran into the page caching issue described here when overriding the default behaviour