### PR TITLE
Option to keep scroll position on page change

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -11,7 +11,7 @@ createDocument          = null
 xhr                     = null
 
 
-fetch = (url) ->
+fetch = (url, keepScroll = false) ->
   url = new ComponentUrl url
 
   rememberReferer()
@@ -20,6 +20,8 @@ fetch = (url) ->
 
   if transitionCacheEnabled and cachedPage = transitionCacheFor(url.absolute)
     fetchHistory cachedPage
+    fetchReplacement url
+  else if keepScroll
     fetchReplacement url
   else
     fetchReplacement url, resetScrollPosition
@@ -320,7 +322,8 @@ class Click
     return if @event.defaultPrevented
     @_extractLink()
     if @_validForTurbolinks()
-      visit @link.href unless pageChangePrevented()
+      keepScroll = @link.link.getAttribute && @link.link.getAttribute('data-keep-scroll')?
+      visit @link.href, keepScroll unless pageChangePrevented()
       @event.preventDefault() 
 
   _extractLink: ->
@@ -403,7 +406,7 @@ else
   visit = (url) -> document.location.href = url
 
 # Public API
-#   Turbolinks.visit(url)
+#   Turbolinks.visit(url, keepScroll=false)
 #   Turbolinks.pagesCached()
 #   Turbolinks.pagesCached(20)
 #   Turbolinks.enableTransitionCache()


### PR DESCRIPTION
This patch enables attaching a “data-keep-scroll” attribute to a link, and clicking it will keep the window’s scroll position instead of scrolling to the top of the page. 

This is a response to this issue: https://github.com/rails/turbolinks/issues/66#issuecomment-14853274
I needed more fine grained control, with some links keeping scroll position and others expressing the default behavior. It's working great for me with this patch. Hopefully this will be helpful to others as well.