### PR TITLE
Pass the XHR object along `page:load`

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -47,7 +47,7 @@ fetchReplacement = (url, onLoadFunction = =>) ->
       changePage extractTitleAndBody(doc)...
       reflectRedirectedUrl()
       onLoadFunction()
-      triggerEvent 'page:load'
+      triggerEvent 'page:load', xhr
     else
       document.location.href = url.absolute
 


### PR DESCRIPTION
This provides us with more information about the new page, such as its headers and URL.  This can be used to integrate, for example, header-based JavaScript dispatch logic:

```ruby
before_filter :set_action

private def set_action
  headers['X-Action'] = action_name
end
```

```javascript
document.addEventListener('page:load', function(event) {
  var xhr = event.data;
  if (xhr.getResponseHeader('X-Action') === 'edit') {
    alert("You're editing something");
  }
});
```