### PR TITLE
Added rememberCurrentState and cacheCurrentPage to the Public API

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -416,4 +416,4 @@ else
 #   Turbolinks.enableTransitionCache()
 #   Turbolinks.allowLinkExtensions('md')
 #   Turbolinks.supported
-@Turbolinks = { visit, pagesCached, enableTransitionCache, allowLinkExtensions: Link.allowExtensions, supported: browserSupportsTurbolinks }
+@Turbolinks = { visit, pagesCached, enableTransitionCache, rememberCurrentState, cacheCurrentPage, allowLinkExtensions: Link.allowExtensions, supported: browserSupportsTurbolinks }


### PR DESCRIPTION
We needed some custom behaviour in our application, we want to cache dynamic pages (backbone/marionette).

We always call these two methods `rememberCurrentState` and `cacheCurrentPage` together, so creating one method that does both would also work for us.

If we completely missed a better way of doing this, please let us know!