### PR TITLE
Do a document.importNode on the new body.

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -92,6 +92,7 @@ constrainPageCacheTo = (limit) ->
     delete pageCache[key]
 
 changePage = (title, body, csrfToken, runScripts) ->
+  body = document.importNode?(body, true);
   document.title = title
   document.documentElement.replaceChild body, document.body
   CSRFToken.update csrfToken if csrfToken?


### PR DESCRIPTION
Setting the document.domain on the consuming page caused IE10 to error out with a WrongDocumentError.