### PR TITLE
Fix back button + hash urls + page cache

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -394,6 +394,7 @@ initializeTurbolinks = ->
   window.addEventListener 'hashchange', (event) ->
     rememberCurrentUrl()
     rememberCurrentState()
+    cacheCurrentPage()
   , false
   bypassOnLoadPopstate ->
     window.addEventListener 'popstate', installHistoryChangeHandler, false


### PR DESCRIPTION
With this sequence:

page1.html -> page1.html#foo -> page2.html -> (back button) -> (back button) -> page1.html#foo -> page2.html -> (back button)

I end up seeing the contents of page1.html instead of page1.html#foo. This was biting me on a page that uses javascript to show a different element based on the URL anchor.