### PR TITLE
Ensure script tags load in order

### DIFF
--- a/test/async.js
+++ b/test/async.js
@@ -1,0 +1,1 @@
+console.log('externally sourced script, should be loaded first')

--- a/test/index.html
+++ b/test/index.html
@@ -34,6 +34,7 @@
     <li><a href="/bounce">Redirect</a></li>
     <li><a href="#">Hash link</a></li>
     <li><a href="/reload.html#foo">New assets track with hash link</a></li>
+    <li><a href="/scripts.html">A page with both an external script and inline script tags</a></li>
     <li><h5>If you stop the server or go into airplane/offline mode</h5></li>
     <li><a href="/doesnotexist.html">A page with client error (4xx, rfc2616 sec. 10.4) should error out</a></li>
     <li><a href="/500">Also server errors (5xx, rfc2616 sec. 10.5) should error out</a></li>

--- a/test/scripts.html
+++ b/test/scripts.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Home</title>
+</head>
+<body class="page-scripts">
+  <script type="text/javascript" src="async.js"></script>
+  <script type="text/javascript">
+    console.log('inline script tag, should be loaded second')
+  </script>
+  <ul>
+    <li><a href="/index.html">Home</a></li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
For each script tag, wait for the external source to be loaded before moving on to the next script tag.

I made this PR because I am working on a project with a page matching exactly this scenario:

1. The first script tag loads a script from a JS file.
2. The second script tag contains inline JS.

Due to the way turbolinks inserts script tags into the DOM very quickly, all external scripts are loaded asynchronously, and seem to always load _after_ any inline scripts.

This PR changes the `executeScriptTags` function so that it inserts the script elements into the DOM one-at-a-time, only after the previous one has loaded.

Before:

![screen shot 2014-12-04 at 10 50 49 am](https://cloud.githubusercontent.com/assets/669/5304084/2ee8e412-7ba4-11e4-859e-0ef3874c6f64.png)

After:

![screen shot 2014-12-04 at 10 53 46 am](https://cloud.githubusercontent.com/assets/669/5304086/32db4128-7ba4-11e4-901d-8fe006b6d5e2.png)
