### PR TITLE
Replace before_filter/after_filter with before_action/after_action

### DIFF
--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -11,8 +11,14 @@ module Turbolinks
       ActiveSupport.on_load(:action_controller) do
         ActionController::Base.class_eval do
           include XHRHeaders, Cookies, XDomainBlocker, Redirection
-          before_filter :set_xhr_redirected_to, :set_request_method_cookie
-          after_filter :abort_xdomain_redirect
+
+          if respond_to?(:before_action)
+            before_action :set_xhr_redirected_to, :set_request_method_cookie
+            after_action :abort_xdomain_redirect
+          else
+            before_filter :set_xhr_redirected_to, :set_request_method_cookie
+            after_filter :abort_xdomain_redirect
+          end
         end
 
         ActionDispatch::Request.class_eval do


### PR DESCRIPTION
Fixes deprecation warnings on Rails master:

```
DEPRECATION WARNING: before_filter is deprecated and will removed in Rails 5.1. Use before_action instead. (called from block (3 levels) in <class:Engine> at /Users/george/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/turbolinks-2.5.3/lib/turbolinks.rb:14)
DEPRECATION WARNING: after_filter is deprecated and will removed in Rails 5.1. Use after_action instead. (called from block (3 levels) in <class:Engine> at /Users/george/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/turbolinks-2.5.3/lib/turbolinks.rb:15)
```