### PR TITLE
Add cacheCurrentPage to public API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,18 @@ Turbolinks.pagesCached();
 Turbolinks.pagesCached(20);
 ```
 
-When a page is removed from the cache due to the cache reaching its size limit, the `page:expire` event is triggered.  Listeners bound to this event can access the cached page object using `event.originalEvent.data`.  Keys of note for this page cache object include `url`, `body`, and `title`.  
+If you need to make dynamic HTML updates in the current page and want it to be cached properly you can call:
+```javascript
+Turbolinks.cacheCurrentPage();
+```
+
+When a page is removed from the cache due to the cache reaching its size limit, the `page:expire` event is triggered.  Listeners bound to this event can access the cached page object using `event.originalEvent.data`.  Keys of note for this page cache object include `url`, `body`, and `title`.
 
 To implement a client-side spinner, you could listen for `page:fetch` to start it and `page:receive` to stop it.
 
 ```javascript
 // using jQuery for simplicity
-    
+
 $(document).on("page:fetch", startSpinner);
 $(document).on("page:receive", stopSpinner);
 ```

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -563,12 +563,14 @@ else
 #   Turbolinks.pagesCached()
 #   Turbolinks.pagesCached(20)
 #   Turbolinks.enableTransitionCache()
+#   Turbolinks.cacheCurrentPage()
 #   Turbolinks.allowLinkExtensions('md')
 #   Turbolinks.supported
 #   Turbolinks.EVENTS
 @Turbolinks = {
   visit,
   pagesCached,
+  cacheCurrentPage,
   enableTransitionCache,
   enableProgressBar,
   allowLinkExtensions: Link.allowExtensions,


### PR DESCRIPTION
I think it would be good to add cacheCurrentPage to the public API of Turbolinks. I'm developing a complex rails application and got to a case where I desperately need it. I'll explain my case in details, but the whole idea can be applied generally.

**My case**
Web application that has many views that can be rendered as a normal page visit (on different URL) and inside of a modal dialog (URL stays the same). When a page is opened in a modal dialog Turbolinks.visit() doesn't get called, but the URL gets manually updated (using history.pushState) so it has the page route that was rendered in the modal. When the modal gets closed, history.back() is called to go to a previous (original) route. So this is about manipulating URL history stack when opening and closing a modal dialog.

**My problem**
Some pages are complex and they can have dynamic HTML updates (drag'n'drops, adding & removing elements with ajax ...) and Turbolinks doesn't properly cache those changes. So when some changes are made on a page, then opened another page in the modal dialog (pushState) and then navigated back to the first page - Turbolinks shows wrong HTML (pulled from cache), without those changes made previously.

**My solution**
Added cacheCurrentPage() to public API of Turbolinks and calling it before each history.pushState(newUrl) fixed all issues.

**Good things if you merge**
* Nothing can break when cacheCurrentPage is exposed
* Added more flexibility to the library because now apps can push custom URL state without caching issues

**Bad things if you merge**
* Added more complexity to the public API and documentation