### PR TITLE
cloudflare compatibility

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -180,9 +180,12 @@ swapNodes = (targetBody, existingNodes, options) ->
 
 executeScriptTags = ->
   scripts = document.body.querySelectorAll 'script:not([data-turbolinks-eval="false"])'
-  for script in scripts when script.type in ['', 'text/javascript']
+  for script in scripts when script.type in ['', 'text/javascript', 'text/rocketscript']
     copy = document.createElement 'script'
-    copy.setAttribute attr.name, attr.value for attr in script.attributes
+    copy.setAttribute attr.name, attr.value for attr in script.attributes when attr not in ['data-rocketsrc']
+    if script.type == 'text/rocketscript'
+      copy.setAttribute 'src', script.attributes['data-rocketsrc'].value if script.attributes['data-rocketsrc']
+      copy.setAttribute 'type', 'text/javascript'
     copy.async = false unless script.hasAttribute 'async'
     copy.appendChild document.createTextNode script.innerHTML
     { parentNode, nextSibling } = script


### PR DESCRIPTION
We had an issue with turbolinks, which caused inline javascript not being executed, if the service is behind cloudflare with rocket loader enabled.

I think what happened is that turbolinks tried to fetch the next page, then cloudflare replaced all javascript script tags with rocketscript tags, which neither rocket.js nor turbolinks executed.

I added the ability to execute rocketscript to the executeScriptTags function.

Please, let me know, what you think.