### PR TITLE
Rack directory needs to run as root on rack

### DIFF
--- a/test/config.ru
+++ b/test/config.ru
@@ -50,10 +50,6 @@ map "/bounce" do
   run Proc.new{ [200, { "X-XHR-Redirected-To" => "redirect1.html", "Content-Type" => "text/html" }, File.open( File.join( Root, "test", "redirect1.html" ) ) ] }
 end
 
-map "/" do
-  run Rack::Directory.new(File.join(Root, "test"))
-end
-
 map "/attachment.txt" do
   run Rack::File.new(File.join(Root, "test", "attachment.html"), "Content-Type" => "text/plain")
 end
@@ -61,3 +57,5 @@ end
 map "/attachment.html" do
   run Rack::File.new(File.join(Root, "test", "attachment.html"), "Content-Type" => "text/html", "Content-Disposition" => "attachment; filename=attachment.html")
 end
+
+run Rack::Directory.new(File.join(Root, "test"))


### PR DESCRIPTION
Without this I get this error, when try to `cd test; rackup`:

```
/Library/Ruby/Gems/2.0.0/gems/rack-1.6.0/lib/rack/builder.rb:146:in `to_app': missing run or map statement (RuntimeError)
	from /Library/Ruby/Gems/2.0.0/gems/rack-1.6.0/lib/rack/builder.rb:160:in `block in generate_map'
	from /Library/Ruby/Gems/2.0.0/gems/rack-1.6.0/lib/rack/builder.rb:160:in `each'
	from /Library/Ruby/Gems/2.0.0/gems/rack-1.6.0/lib/rack/builder.rb:160:in `generate_map'
	from /Library/Ruby/Gems/2.0.0/gems/rack-1.6.0/lib/rack/builder.rb:145:in `to_app'
	from /Users/arthurnn/dev/turbolinks/test/config.ru:65:in `<main>'
	from /Library/Ruby/Gems/2.0.0/gems/rack-1.6.0/lib/rack/builder.rb:49:in `eval'
	from /Library/Ruby/Gems/2.0.0/gems/rack-1.6.0/lib/rack/builder.rb:49:in `new_from_string'
	from /Library/Ruby/Gems/2.0.0/gems/rack-1.6.0/lib/rack/builder.rb:40:in `parse_file'
	from /Library/Ruby/Gems/2.0.0/gems/rack-1.6.0/lib/rack/server.rb:299:in `build_app_and_options_from_config'
	from /Library/Ruby/Gems/2.0.0/gems/rack-1.6.0/lib/rack/server.rb:208:in `app'
	from /Library/Ruby/Gems/2.0.0/gems/rack-1.6.0/lib/rack/server.rb:336:in `wrapped_app'
	from /Library/Ruby/Gems/2.0.0/gems/rack-1.6.0/lib/rack/server.rb:272:in `start'
	from /Library/Ruby/Gems/2.0.0/gems/rack-1.6.0/lib/rack/server.rb:147:in `start'
	from /Library/Ruby/Gems/2.0.0/gems/rack-1.6.0/bin/rackup:4:in `<top (required)>'
	from /usr/bin/rackup:23:in `load'
	from /usr/bin/rackup:23:in `<main>'
```

review @dhh @rafaelfranca