### PR TITLE
Fix exception when X-XHR-Referer isn't a invalid URI

### DIFF
--- a/lib/turbolinks/x_domain_blocker.rb
+++ b/lib/turbolinks/x_domain_blocker.rb
@@ -11,11 +11,12 @@ module Turbolinks
       end
 
       def abort_xdomain_redirect
-        to_uri = response.headers['Location'] || ""
-        current = request.headers['X-XHR-Referer'] || ""
+        to_uri = response.headers['Location']
+        current = request.headers['X-XHR-Referer']
         unless to_uri.blank? || current.blank? || same_origin?(current, to_uri)
           self.status = 403
         end
+      rescue URI::InvalidURIError
       end
   end
 end

--- a/test/turbolinks/turbolinks_test.rb
+++ b/test/turbolinks/turbolinks_test.rb
@@ -20,6 +20,10 @@ class TurbolinksController < ActionController::Base
   def redirect_to_back
     redirect_to :back
   end
+
+  def redirect_to_unescaped_path
+    redirect_to "#{request.protocol}#{request.host}/foo bar"
+  end
 end
 
 class TurbolinksTest < ActionController::TestCase
@@ -93,5 +97,23 @@ class TurbolinksTest < ActionController::TestCase
 
     get :redirect_to_same_origin
     assert_response :redirect
+  end
+
+  def test_handles_invalid_xhr_referer_on_redirection
+    @request.headers['X-XHR-Referer'] = ':'
+    get :redirect_to_same_origin
+    assert_response :redirect
+  end
+
+  def test_handles_unescaped_same_origin_location_on_redirection
+    @request.headers['X-XHR-Referer'] = 'http://test.host/'
+    get :redirect_to_unescaped_path
+    assert_response :redirect
+  end
+
+  def test_handles_unescaped_different_origin_location_on_redirection
+    @request.headers['X-XHR-Referer'] = 'https://test.host/'
+    get :redirect_to_unescaped_path
+    assert_response :forbidden
   end
 end


### PR DESCRIPTION
- Fix: client sends invalid `X-XHR-Referer` → [`XDomainBlocker`](https://github.com/rails/turbolinks/blob/91d8cc8810dc8ee63f9394780b04171c543c006c/lib/turbolinks/x_domain_blocker.rb#L8) raises `URI::InvalidURIError`
- Get rid of `'same_origin?': warning: URI.escape is obsolete`

@arthurnn @reed @dhh 