### PR TITLE
Add JS tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.lock
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "turbolinks",
+  "description": "turbolinks test suite",
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rails/turbolinks.git"
+  },
+  "devDependencies": {
+    "mocha": "~2.1.0",
+    "chai": "~2.1.0"
+  }
+}

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'sprockets', '~> 2.8.0'
+gem 'coffee-script', '~> 2.2.0'

--- a/test/config.ru
+++ b/test/config.ru
@@ -5,6 +5,9 @@ Root = File.expand_path("../..", __FILE__)
 
 Assets = Sprockets::Environment.new do |env|
   env.append_path File.join(Root, "lib", "assets", "javascripts")
+  env.append_path File.join(Root, "node_modules", "mocha")
+  env.append_path File.join(Root, "node_modules", "chai")
+  env.append_path File.join(Root, "test", "javascript")
 end
 
 class SlowResponse

--- a/test/javascript/iframe.html
+++ b/test/javascript/iframe.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>title</title>
+  <meta content="authenticity_token" name="csrf-param">
+  <meta content="token" name="csrf-token">
+  <script src="/js/turbolinks.js"></script>
+</head>
+<body>
+  <div id="div">div content</div>
+  <div id="change">change content</div>
+  <div id="change:key">change content</div>
+  <div id="permanent" data-turbolinks-permanent>permanent content</div>
+  <div id="temporary" data-turbolinks-temporary>temporary content</div>
+</body>
+</html>

--- a/test/javascript/index.html
+++ b/test/javascript/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Turbolinks Tests</title>
+  <link rel="stylesheet" href="/js/mocha.css">
+</head>
+<body>
+  <div id="mocha"></div>
+  <script src="/js/mocha.js"></script>
+  <script src="/js/chai.js"></script>
+  <script>mocha.setup('tdd');</script>
+  <script src="/js/turbolinks_replace_test.js"></script>
+  <script>
+    mocha.checkLeaks();
+    mocha.run();
+  </script>
+</body>
+</html>

--- a/test/javascript/turbolinks_replace_test.coffee
+++ b/test/javascript/turbolinks_replace_test.coffee
@@ -1,0 +1,158 @@
+assert = chai.assert
+
+suite 'Turbolinks.replace()', ->
+  setup (done) ->
+    @iframe = document.createElement('iframe')
+    @iframe.style.display = 'none'
+    @iframe.setAttribute('src', 'iframe.html')
+    document.body.appendChild(@iframe)
+    @iframe.onload = =>
+      @window = @iframe.contentWindow
+      @document = @window.document
+      @Turbolinks = @window.Turbolinks
+      @$ = (selector) => @document.querySelector(selector)
+      done()
+
+  teardown ->
+    document.body.removeChild(@iframe)
+
+  test "default", (done) ->
+    doc = """
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <meta charset="utf-8">
+        <title>new title</title>
+        <meta content="new-token" name="csrf-token">
+        <script>var headScript = true</script>
+      </head>
+      <body new-attribute>
+        <div id="new-div"></div>
+        <div id="permanent" data-turbolinks-permanent>new content</div>
+        <div id="temporary" data-turbolinks-temporary>new content</div>
+        <script>var bodyScript = true</script>
+        <script data-turbolinks-eval="false">var bodyScriptEvalFalse = true</script>
+      </body>
+      </html>
+    """
+    body = @$('body')
+    permanent = @$('#permanent')
+    beforeUnloadFired = false
+    @document.addEventListener 'page:before-unload', =>
+      assert.notOk @window.bodyScript
+      assert.notOk @$('#new-div')
+      assert.notOk @$('body').hasAttribute('new-attribute')
+      assert.ok @$('#div')
+      assert.equal @$('meta[name="csrf-token"]').getAttribute('content'), 'token'
+      assert.equal @document.title, 'title'
+      assert.equal @$('body'), body
+      beforeUnloadFired = true
+    @document.addEventListener 'page:change', =>
+      assert.ok beforeUnloadFired
+      assert.ok @window.bodyScript
+      assert.notOk @window.headScript
+      assert.notOk @window.bodyScriptEvalFalse
+      assert.ok @$('#new-div')
+      assert.ok @$('body').hasAttribute('new-attribute')
+      assert.notOk @$('#div')
+      assert.equal @$('#permanent').textContent, 'permanent content'
+      assert.equal @document.title, 'new title'
+      assert.equal @$('meta[name="csrf-token"]').getAttribute('content'), 'new-token'
+      assert.notEqual @$('#permanent'), permanent # permanent nodes are cloned
+      assert.notEqual @$('body'), body # body is replaced
+      done()
+    @Turbolinks.replace(doc)
+
+  test "with :flush", (done) ->
+    doc = """
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <meta charset="utf-8">
+        <title></title>
+      </head>
+      <body>
+        <div id="permanent" data-turbolinks-permanent>new content</div>
+      </body>
+      </html>
+    """
+    beforeUnloadFired = false
+    @document.addEventListener 'page:before-unload', =>
+      assert.equal @$('#permanent').textContent, 'permanent content'
+      beforeUnloadFired = true
+    @document.addEventListener 'page:change', =>
+      assert.ok beforeUnloadFired
+      assert.equal @$('#permanent').textContent, 'new content'
+      done()
+    @Turbolinks.replace(doc, flush: true)
+
+  test "with :keep", (done) ->
+    doc = """
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <meta charset="utf-8">
+        <title></title>
+      </head>
+      <body>
+        <div id="div">new content</div>
+      </body>
+      </html>
+    """
+    beforeUnloadFired = false
+    @document.addEventListener 'page:before-unload', =>
+      assert.equal @$('#div').textContent, 'div content'
+      beforeUnloadFired = true
+    @document.addEventListener 'page:change', =>
+      assert.ok beforeUnloadFired
+      assert.equal @$('#div').textContent, 'div content'
+      done()
+    @Turbolinks.replace(doc, keep: ['div'])
+
+  test "with :change", (done) ->
+    doc = """
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <meta charset="utf-8">
+        <title>new title</title>
+        <meta content="new-token" name="csrf-token">
+        <script>var headScript = true</script>
+      </head>
+      <body new-attribute>
+        <div id="new-div"></div>
+        <div id="div">new content</div>
+        <div id="change">new content</div>
+        <div id="change:key">new content</div>
+        <div id="permanent" data-turbolinks-permanent>new content</div>
+        <div id="temporary" data-turbolinks-temporary>new content</div>
+        <script>var bodyScript = true</script>
+      </body>
+      </html>
+    """
+    body = @$('body')
+    change = @$('#change')
+    beforeUnloadFired = false
+    @document.addEventListener 'page:before-unload', =>
+      assert.equal @$('#change').textContent, 'change content'
+      assert.equal @$('[id="change:key"]').textContent, 'change content'
+      assert.equal @$('#temporary').textContent, 'temporary content'
+      assert.equal @document.title, 'title'
+      beforeUnloadFired = true
+    @document.addEventListener 'page:change', =>
+      assert.ok beforeUnloadFired
+      assert.notOk @window.bodyScript
+      assert.notOk @window.headScript
+      assert.notOk @$('#new-div')
+      assert.notOk @$('body').hasAttribute('new-attribute')
+      assert.equal @$('#change').textContent, 'new content'
+      assert.equal @$('[id="change:key"]').textContent, 'new content'
+      assert.equal @$('#temporary').textContent, 'new content'
+      assert.equal @$('#div').textContent, 'div content'
+      assert.equal @$('#permanent').textContent, 'permanent content'
+      assert.equal @$('meta[name="csrf-token"]').getAttribute('content'), 'token'
+      assert.equal @document.title, 'new title'
+      assert.notEqual @$('#change'), change # changed nodes are cloned
+      assert.equal @$('body'), body
+      done()
+    @Turbolinks.replace(doc, change: ['change'])


### PR DESCRIPTION
This adds JS tests for `Turbolinks.replace` / the partial replacement feature added in #468.

- Add `Gemfile` for the test app, locking-in the default versions of `sprockets` and `coffee-script` in Rails 4.0.

- JS test setup:
  ```
npm install
cd test
bundle install
bundle exec rackup
open http://localhost:9292/javascript/index.html
```
  ![turbolinks tests 2015-02-28 22-48-46](https://cloud.githubusercontent.com/assets/17579/6429399/27a124f8-bf9c-11e4-874d-21736f67ef43.png)

- Each test runs in an iframe powered by the Rack app, so we can run multi-page tests with ease, no leaks, and no fake XHRs.

@dhh @kristianpd @arthurnn @reed let me know what you think :)

Happy to write more tests to let us refactor without fear and make sure Turbolinks works in all browsers.