### PR TITLE
Add test instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,28 @@ Installation
 1. Add `//= require turbolinks` to your Javascript manifest file (usually found at `app/assets/javascripts/application.js`). If your manifest requires both turbolinks and jQuery, make sure turbolinks is listed *after* jQuery.
 1. Restart your server and you're now using turbolinks!
 
+Running the tests
+-----------------
+
+Ruby:
+
+```
+rake test:all 
+
+BUNDLE_GEMFILE=Gemfile.rails42 bundle
+BUNDLE_GEMFILE=Gemfile.rails42 rake test 
+```
+
+JavaScript:
+
+```
+npm install
+cd test
+bundle
+bundle exec rackup
+open http://localhost:9292/javascript/index.html
+```
+
 Language Ports
 --------------
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,12 @@ Rake::TestTask.new do |t|
   t.warning = true
   t.verbose = true
 end
+
+namespace :test do
+  task :all do
+    %w(rails40 rails41 rails42).each do |gemfile|
+      sh "BUNDLE_GEMFILE='Gemfile.#{gemfile}' bundle --quiet"
+      sh "BUNDLE_GEMFILE='Gemfile.#{gemfile}' bundle exec rake test"
+    end
+  end
+end


### PR DESCRIPTION
- Add `rake test:all` to run the tests against all Gemfiles
- Add test instructions to the README