### PR TITLE
Don't clone data-turbolinks-permanent and :keep nodes

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -172,7 +172,7 @@ swapNodes = (targetBody, existingNodes, options) ->
 
     if targetNode = targetBody.querySelector('[id="'+nodeId+'"]')
       if options.keep
-        existingNode = existingNode.cloneNode(true)
+        targetBody.ownerDocument.adoptNode(existingNode)
         targetNode.parentNode.replaceChild(existingNode, targetNode)
       else
         targetNode = targetNode.cloneNode(true)

--- a/test/javascript/turbolinks_replace_test.coffee
+++ b/test/javascript/turbolinks_replace_test.coffee
@@ -37,6 +37,7 @@ suite 'Turbolinks.replace()', ->
     """
     body = @$('body')
     permanent = @$('#permanent')
+    permanent.addEventListener 'click', -> done()
     beforeUnloadFired = false
     @document.addEventListener 'page:before-unload', =>
       assert.notOk @window.bodyScript
@@ -58,9 +59,9 @@ suite 'Turbolinks.replace()', ->
       assert.equal @$('#permanent').textContent, 'permanent content'
       assert.equal @document.title, 'new title'
       assert.equal @$('meta[name="csrf-token"]').getAttribute('content'), 'new-token'
-      assert.notEqual @$('#permanent'), permanent # permanent nodes are cloned
       assert.notEqual @$('body'), body # body is replaced
-      done()
+      assert.equal @$('#permanent'), permanent # permanent nodes are transferred
+      @$('#permanent').click() # event listeners on permanent nodes should not be lost
     @Turbolinks.replace(doc)
 
   test "with :flush", (done) ->
@@ -100,13 +101,16 @@ suite 'Turbolinks.replace()', ->
       </html>
     """
     beforeUnloadFired = false
+    div = @$('#div')
+    div.addEventListener 'click', -> done()
     @document.addEventListener 'page:before-unload', =>
       assert.equal @$('#div').textContent, 'div content'
       beforeUnloadFired = true
     @document.addEventListener 'page:change', =>
       assert.ok beforeUnloadFired
       assert.equal @$('#div').textContent, 'div content'
-      done()
+      assert.equal @$('#div'), div # :keep nodes are transferred
+      @$('#div').click() # event listeners on :keep nodes should not be lost
     @Turbolinks.replace(doc, keep: ['div'])
 
   test "with :change", (done) ->

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -21,6 +21,7 @@ suite 'Turbolinks.visit()', ->
   test "successful", (done) ->
     body = @$('body')
     permanent = @$('#permanent')
+    permanent.addEventListener 'click', -> done()
     pageReceivedFired = beforeUnloadFired = false
     @document.addEventListener 'page:receive', =>
       state = turbolinks: true, url: 'http://localhost:9292/javascript/iframe.html'
@@ -48,13 +49,14 @@ suite 'Turbolinks.visit()', ->
       assert.equal @$('#temporary').textContent, 'temporary content 2'
       assert.equal @document.title, 'title 2'
       assert.equal @$('meta[name="csrf-token"]').getAttribute('content'), 'token2'
-      assert.notEqual @$('#permanent'), permanent # permanent nodes are cloned
       assert.notEqual @$('body'), body # body is replaced
 
       state = turbolinks: true, url: 'http://localhost:9292/javascript/iframe2.html'
       assert.deepEqual @history.state, state
       assert.equal @location.href, state.url
-      done()
+
+      assert.equal @$('#permanent'), permanent # permanent nodes are transferred
+      @$('#permanent').click() # event listeners on permanent nodes should not be lost
     @Turbolinks.visit('iframe2.html')
 
   test "successful with :change", (done) ->


### PR DESCRIPTION
Fix #477

Tests pass in latest Firefox, Chrome, Safari and IE10.

cc @reed @dhh @kristianpd @jtomaszewski 