### PR TITLE
Fix and improve <script> execution

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -182,7 +182,7 @@ swapNodes = (targetBody, existingNodes, options) ->
   return
 
 executeScriptTags = ->
-  scripts = Array::slice.call document.body.querySelectorAll 'script:not([data-turbolinks-eval="false"])'
+  scripts = document.body.querySelectorAll 'script:not([data-turbolinks-eval="false"])'
   for script in scripts when script.type in ['', 'text/javascript']
     copy = document.createElement 'script'
     copy.setAttribute attr.name, attr.value for attr in script.attributes

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -93,7 +93,7 @@ fetchReplacement = (url, options) ->
 
 fetchHistory = (cachedPage) ->
   xhr?.abort()
-  changePage createDocument(cachedPage.body.outerHTML), title: cachedPage.title
+  changePage createDocument(cachedPage.body.outerHTML), title: cachedPage.title, runScripts: false
   progressBar?.done()
   recallScrollPosition cachedPage
   triggerEvent EVENTS.RESTORE
@@ -130,7 +130,7 @@ replace = (html, options = {}) ->
   changePage createDocument(html), options
 
 changePage = (doc, options) ->
-  [title, targetBody, csrfToken, runScripts] = extractTitleAndBody(doc)
+  [title, targetBody, csrfToken] = extractTitleAndBody(doc)
   title ?= options.title
 
   triggerEvent EVENTS.BEFORE_UNLOAD
@@ -148,7 +148,7 @@ changePage = (doc, options) ->
     document.documentElement.replaceChild targetBody, document.body
     CSRFToken.update csrfToken if csrfToken?
     setAutofocusElement()
-    executeScriptTags() if runScripts
+    executeScriptTags() unless options.runScripts is false
 
   currentState = window.history.state
 
@@ -301,7 +301,7 @@ processResponse = ->
 
 extractTitleAndBody = (doc) ->
   title = doc.querySelector 'title'
-  [ title?.textContent, removeNoscriptTags(doc.querySelector('body')), CSRFToken.get(doc).token, 'runScripts' ]
+  [ title?.textContent, removeNoscriptTags(doc.querySelector('body')), CSRFToken.get(doc).token ]
 
 CSRFToken =
   get: (doc = document) ->

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -148,8 +148,8 @@ changePage = (doc, options) ->
     document.documentElement.replaceChild targetBody, document.body
     CSRFToken.update csrfToken if csrfToken?
     setAutofocusElement()
-    executeScriptTags() unless options.runScripts is false
 
+  executeScriptTags() unless options.runScripts is false
   currentState = window.history.state
 
   triggerEvent EVENTS.CHANGE
@@ -177,8 +177,6 @@ swapNodes = (targetBody, existingNodes, options) ->
       else
         targetNode = targetNode.cloneNode(true)
         existingNode.parentNode.replaceChild(targetNode, existingNode)
-        if targetNode.nodeName == 'SCRIPT' && targetNode.getAttribute("data-turbolinks-eval") != "false"
-          executeScriptTag(targetNode)
   return
 
 executeScriptTags = ->

--- a/test/javascript/iframe.html
+++ b/test/javascript/iframe.html
@@ -13,5 +13,6 @@
   <div id="change:key">change content</div>
   <div id="permanent" data-turbolinks-permanent>permanent content</div>
   <div id="temporary" data-turbolinks-temporary>temporary content</div>
+  <script>window.i = window.i || 0; window.i++;</script>
 </body>
 </html>

--- a/test/javascript/iframe2.html
+++ b/test/javascript/iframe2.html
@@ -14,6 +14,7 @@
   <div id="change:key">change content 2</div>
   <div id="permanent" data-turbolinks-permanent>permanent content 2</div>
   <div id="temporary" data-turbolinks-temporary>temporary content 2</div>
+  <script id="script">document.body.removeChild(document.getElementById('script'))</script>
   <script>window.bodyScript = window.bodyScript || 0; window.bodyScript++;</script>
   <script data-turbolinks-eval="false">var bodyScriptEvalFalse = true</script>
 </body>

--- a/test/javascript/iframe2.html
+++ b/test/javascript/iframe2.html
@@ -14,7 +14,7 @@
   <div id="change:key">change content 2</div>
   <div id="permanent" data-turbolinks-permanent>permanent content 2</div>
   <div id="temporary" data-turbolinks-temporary>temporary content 2</div>
-  <script>var bodyScript = true</script>
+  <script>window.bodyScript = window.bodyScript || 0; window.bodyScript++;</script>
   <script data-turbolinks-eval="false">var bodyScriptEvalFalse = true</script>
 </body>
 </html>

--- a/test/javascript/iframe2.html
+++ b/test/javascript/iframe2.html
@@ -15,7 +15,7 @@
   <div id="permanent" data-turbolinks-permanent>permanent content 2</div>
   <div id="temporary" data-turbolinks-temporary>temporary content 2</div>
   <script id="script">document.body.removeChild(document.getElementById('script'))</script>
-  <script>window.bodyScript = window.bodyScript || 0; window.bodyScript++;</script>
+  <script>window.j = window.j || 0; window.j++;</script>
   <script data-turbolinks-eval="false">var bodyScriptEvalFalse = true</script>
 </body>
 </html>

--- a/test/javascript/turbolinks_replace_test.coffee
+++ b/test/javascript/turbolinks_replace_test.coffee
@@ -30,7 +30,7 @@ suite 'Turbolinks.replace()', ->
         <div id="new-div"></div>
         <div id="permanent" data-turbolinks-permanent>new content</div>
         <div id="temporary" data-turbolinks-temporary>new content</div>
-        <script>var bodyScript = true</script>
+        <script>window.bodyScript = window.bodyScript || 0; window.bodyScript++;</script>
         <script data-turbolinks-eval="false">var bodyScriptEvalFalse = true</script>
       </body>
       </html>
@@ -40,7 +40,7 @@ suite 'Turbolinks.replace()', ->
     permanent.addEventListener 'click', -> done()
     beforeUnloadFired = false
     @document.addEventListener 'page:before-unload', =>
-      assert.notOk @window.bodyScript
+      assert.isUndefined @window.bodyScript
       assert.notOk @$('#new-div')
       assert.notOk @$('body').hasAttribute('new-attribute')
       assert.ok @$('#div')
@@ -50,9 +50,9 @@ suite 'Turbolinks.replace()', ->
       beforeUnloadFired = true
     @document.addEventListener 'page:change', =>
       assert.ok beforeUnloadFired
-      assert.ok @window.bodyScript
-      assert.notOk @window.headScript
-      assert.notOk @window.bodyScriptEvalFalse
+      assert.strictEqual @window.bodyScript, 1
+      assert.isUndefined @window.headScript
+      assert.isUndefined @window.bodyScriptEvalFalse
       assert.ok @$('#new-div')
       assert.ok @$('body').hasAttribute('new-attribute')
       assert.notOk @$('#div')
@@ -145,8 +145,8 @@ suite 'Turbolinks.replace()', ->
       beforeUnloadFired = true
     @document.addEventListener 'page:change', =>
       assert.ok beforeUnloadFired
-      assert.notOk @window.bodyScript
-      assert.notOk @window.headScript
+      assert.isUndefined @window.bodyScript
+      assert.isUndefined @window.headScript
       assert.notOk @$('#new-div')
       assert.notOk @$('body').hasAttribute('new-attribute')
       assert.equal @$('#change').textContent, 'new content'

--- a/test/javascript/turbolinks_replace_test.coffee
+++ b/test/javascript/turbolinks_replace_test.coffee
@@ -30,7 +30,7 @@ suite 'Turbolinks.replace()', ->
         <div id="new-div"></div>
         <div id="permanent" data-turbolinks-permanent>new content</div>
         <div id="temporary" data-turbolinks-temporary>new content</div>
-        <script>window.bodyScript = window.bodyScript || 0; window.bodyScript++;</script>
+        <script>window.j = window.j || 0; window.j++;</script>
         <script data-turbolinks-eval="false">var bodyScriptEvalFalse = true</script>
       </body>
       </html>
@@ -40,7 +40,7 @@ suite 'Turbolinks.replace()', ->
     permanent.addEventListener 'click', -> done()
     beforeUnloadFired = false
     @document.addEventListener 'page:before-unload', =>
-      assert.isUndefined @window.bodyScript
+      assert.isUndefined @window.j
       assert.notOk @$('#new-div')
       assert.notOk @$('body').hasAttribute('new-attribute')
       assert.ok @$('#div')
@@ -50,7 +50,7 @@ suite 'Turbolinks.replace()', ->
       beforeUnloadFired = true
     @document.addEventListener 'page:change', =>
       assert.ok beforeUnloadFired
-      assert.strictEqual @window.bodyScript, 1
+      assert.equal @window.j, 1
       assert.isUndefined @window.headScript
       assert.isUndefined @window.bodyScriptEvalFalse
       assert.ok @$('#new-div')
@@ -138,6 +138,7 @@ suite 'Turbolinks.replace()', ->
     change = @$('#change')
     beforeUnloadFired = false
     @document.addEventListener 'page:before-unload', =>
+      assert.equal @window.i, 1
       assert.equal @$('#change').textContent, 'change content'
       assert.equal @$('[id="change:key"]').textContent, 'change content'
       assert.equal @$('#temporary').textContent, 'temporary content'
@@ -145,6 +146,7 @@ suite 'Turbolinks.replace()', ->
       beforeUnloadFired = true
     @document.addEventListener 'page:change', =>
       assert.ok beforeUnloadFired
+      assert.equal @window.i, 2
       assert.isUndefined @window.bodyScript
       assert.isUndefined @window.headScript
       assert.notOk @$('#new-div')

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -108,6 +108,7 @@ suite 'Turbolinks.visit()', ->
         setTimeout (=> @Turbolinks.visit('iframe.html')), 0
       else if load is 2
         assert.notOk restoreCalled
+        assert.equal @window.i, 2
         assert.equal @document.title, 'title'
         done()
     @document.addEventListener 'page:restore', =>
@@ -124,10 +125,12 @@ suite 'Turbolinks.visit()', ->
         setTimeout (=> @Turbolinks.visit('iframe.html')), 0
       else if load is 2
         assert.ok restoreCalled
+        assert.equal @window.i, 2
         assert.equal @document.title, 'title'
         done()
     @document.addEventListener 'page:restore', =>
       assert.equal load, 1
+      assert.equal @window.i, 1
       assert.equal @document.title, 'title'
       restoreCalled = true
     @Turbolinks.enableTransitionCache()

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -28,7 +28,7 @@ suite 'Turbolinks.visit()', ->
       assert.deepEqual @history.state, state
       pageReceivedFired = true
     @document.addEventListener 'page:before-unload', =>
-      assert.isUndefined @window.bodyScript
+      assert.isUndefined @window.j
       assert.notOk @$('#new-div')
       assert.notOk @$('body').hasAttribute('new-attribute')
       assert.ok @$('#div')
@@ -39,7 +39,8 @@ suite 'Turbolinks.visit()', ->
     @document.addEventListener 'page:load', =>
       assert.ok pageReceivedFired
       assert.ok beforeUnloadFired
-      assert.strictEqual @window.bodyScript, 1
+      assert.equal @window.i, 1
+      assert.equal @window.j, 1
       assert.isUndefined @window.headScript
       assert.isUndefined @window.bodyScriptEvalFalse
       assert.ok @$('#new-div')
@@ -64,6 +65,7 @@ suite 'Turbolinks.visit()', ->
     change = @$('#change')
     beforeUnloadFired = false
     @document.addEventListener 'page:before-unload', =>
+      assert.equal @window.i, 1
       assert.equal @$('#change').textContent, 'change content'
       assert.equal @$('[id="change:key"]').textContent, 'change content'
       assert.equal @$('#temporary').textContent, 'temporary content'
@@ -71,8 +73,10 @@ suite 'Turbolinks.visit()', ->
       beforeUnloadFired = true
     @document.addEventListener 'page:load', =>
       assert.ok beforeUnloadFired
-      assert.isUndefined @window.bodyScript
+      assert.equal @window.i, 2
+      assert.isUndefined @window.j
       assert.isUndefined @window.headScript
+      assert.isUndefined @window.bodyScriptEvalFalse
       assert.notOk @$('#new-div')
       assert.notOk @$('body').hasAttribute('new-attribute')
       assert.equal @$('#change').textContent, 'change content 2'

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -28,7 +28,7 @@ suite 'Turbolinks.visit()', ->
       assert.deepEqual @history.state, state
       pageReceivedFired = true
     @document.addEventListener 'page:before-unload', =>
-      assert.notOk @window.bodyScript
+      assert.isUndefined @window.bodyScript
       assert.notOk @$('#new-div')
       assert.notOk @$('body').hasAttribute('new-attribute')
       assert.ok @$('#div')
@@ -39,9 +39,9 @@ suite 'Turbolinks.visit()', ->
     @document.addEventListener 'page:load', =>
       assert.ok pageReceivedFired
       assert.ok beforeUnloadFired
-      assert.ok @window.bodyScript
-      assert.notOk @window.headScript
-      assert.notOk @window.bodyScriptEvalFalse
+      assert.strictEqual @window.bodyScript, 1
+      assert.isUndefined @window.headScript
+      assert.isUndefined @window.bodyScriptEvalFalse
       assert.ok @$('#new-div')
       assert.ok @$('body').hasAttribute('new-attribute')
       assert.notOk @$('#div')
@@ -71,8 +71,8 @@ suite 'Turbolinks.visit()', ->
       beforeUnloadFired = true
     @document.addEventListener 'page:load', =>
       assert.ok beforeUnloadFired
-      assert.notOk @window.bodyScript
-      assert.notOk @window.headScript
+      assert.isUndefined @window.bodyScript
+      assert.isUndefined @window.headScript
       assert.notOk @$('#new-div')
       assert.notOk @$('body').hasAttribute('new-attribute')
       assert.equal @$('#change').textContent, 'change content 2'


### PR DESCRIPTION
- Don't run scripts when restoring page from cache (broken by 7c9d6b279b9d21c2d81b75bc32b43193bb070196)

- Better tests (assert scripts are only run once)

- ~~Remove unnecessary call to `executeScriptTag` that could lead to double-execution (haven't added a regression test for this as I don't understand what the use-case was intended to be)~~
  See inline comments

- Remove unnecessary NodeList-to-Array conversion