### PR TITLE
Replacement is susceptible to memory leaks. Send an event when a node is replaced so things can be cleaned up

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -20,6 +20,7 @@ EVENTS =
   RESTORE:        'page:restore'
   BEFORE_UNLOAD:  'page:before-unload'
   EXPIRE:         'page:expire'
+  REMOVED:        'page:after-node-removed'
 
 fetch = (url, options = {}) ->
   url = new ComponentUrl url
@@ -145,7 +146,8 @@ changePage = (doc, options) ->
       nodesToBeKept.push(findNodesMatchingKeys(document.body, options.keep)...) if options.keep
       swapNodes(targetBody, nodesToBeKept, keep: true)
 
-    document.documentElement.replaceChild targetBody, document.body
+    replacedNode = document.documentElement.replaceChild targetBody, document.body
+    triggerEvent(EVENTS.REMOVED, replacedNode)
     CSRFToken.update csrfToken if csrfToken?
     setAutofocusElement()
 
@@ -176,7 +178,8 @@ swapNodes = (targetBody, existingNodes, options) ->
         targetNode.parentNode.replaceChild(existingNode, targetNode)
       else
         targetNode = targetNode.cloneNode(true)
-        existingNode.parentNode.replaceChild(targetNode, existingNode)
+        replacedNode = existingNode.parentNode.replaceChild(targetNode, existingNode)
+        triggerEvent(EVENTS.REMOVED, replacedNode)
   return
 
 executeScriptTags = ->


### PR DESCRIPTION
I noticed when using jQuery that if there is a bound function used as a callback for a jQuery event on a node that is replaced, the object the function belongs to never gets garbage collected. It's happening because when using native DOM manipulation jQuery event listeners do not get cleaned up; we need to use specific functions in jQuery to ensure that.

For example, this leaks an instance of Leak:
```coffeescript
class window.Leak
  constructor: (node, @data) ->
    $(node).on "change", @onNodeChanged

  onNodeChanged: =>
    console.log "node changed with data", @data

node = $('<div></div>')[0]
document.body.appendChild(node)

new Leak(node)
$(node).trigger('change')

node2 = $('<span></span>')[0]
document.body.replaceChild(node2, node)
node = null
```
If you do `$(node).remove()` before `node = null` then there's no leak.

This change won't actually clean up the memory leak, but if someone uses jQuery in their project then adding something like the following will fix the leak:
```coffeescript
document.addEventListener 'page:after-node-removed', (event) ->
  $(event.data).remove()
```

See the leak happening [here](https://jsfiddle.net/L79m91ww/). To see the leak (in chrome)
* Run the snippet
* In the dev tools, open profiles and make a heap snapshop
* At the top, enter Leak in the Class filter input. You'll see that there's an instance in memory

To see it fixed, uncomment the remove line at the bottom and repeat.