### PR TITLE
Trigger an event after removing nodes to prevent memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@
 
     *Kristian Plettenberg-Dussault*, *Thibaut Courouble*, *David Heinemeier Hansson*
 
+*   Add a `page:after-remove` event, triggered after a node (stored in `event.data`) is removed from the DOM, to give user scripts the opportunity to clean up references and data related to these nodes (e.g. `jQuery.fn.remove()`), and avoid memory leaks.
+
+    *Thibaut Courouble*, *Drew Martin*
+
 *   Fix `URI::InvalidURIError` when `X-XHR-Referer` is invalid and the request performs a redirection.
 
     *Thibaut Courouble*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@
 
 *   Add a `page:after-remove` event, triggered after a node (stored in `event.data`) is removed from the DOM, to give user scripts the opportunity to clean up references and data related to these nodes (e.g. `jQuery.fn.remove()`), and avoid memory leaks.
 
+    This event replaces the `page:expire` event for cleaning up cached pages.
+
     *Thibaut Courouble*, *Drew Martin*
 
 *   Fix `URI::InvalidURIError` when `X-XHR-Referer` is invalid and the request performs a redirection.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ With Turbolinks pages will change without a full reload, so you can't rely on `D
 * `page:fetch` starting to fetch a new target page
 * `page:receive` the page has been fetched from the server, but not yet parsed
 * `page:before-unload` the page has been parsed and is about to be changed
+* `page:after-remove` a node (stored in `event.data`) has been removed from the DOM and should be cleaned up (e.g. with `jQuery.fn.remove()`)
 * `page:change` the page has been changed to the new version (and on DOMContentLoaded)
 * `page:update` is triggered alongside both page:change and jQuery's ajaxSuccess (if jQuery is available - otherwise you can manually trigger it when calling XMLHttpRequest in your own code)
 * `page:load` is fired at the end of the loading process.

--- a/README.md
+++ b/README.md
@@ -64,8 +64,6 @@ If you need to make dynamic HTML updates in the current page and want it to be c
 Turbolinks.cacheCurrentPage();
 ```
 
-When a page is removed from the cache due to the cache reaching its size limit, the `page:expire` event is triggered.  Listeners bound to this event can access the cached page object using `event.originalEvent.data`.  Keys of note for this page cache object include `url`, `body`, and `title`.
-
 To implement a client-side spinner, you could listen for `page:fetch` to start it and `page:receive` to stop it.
 
 ```javascript

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -20,7 +20,6 @@ EVENTS =
   LOAD:           'page:load'
   RESTORE:        'page:restore'
   BEFORE_UNLOAD:  'page:before-unload'
-  EXPIRE:         'page:expire'
   AFTER_REMOVE:   'page:after-remove'
 
 fetch = (url, options = {}) ->
@@ -122,7 +121,6 @@ constrainPageCacheTo = (limit) ->
   .sort (a, b) -> b - a
 
   for key in pageCacheKeys when pageCache[key].cachedAt <= cacheTimesRecentFirst[limit]
-    triggerEvent EVENTS.EXPIRE, pageCache[key]
     delete pageCache[key]
 
 replace = (html, options = {}) ->

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -21,6 +21,7 @@ EVENTS =
   RESTORE:        'page:restore'
   BEFORE_UNLOAD:  'page:before-unload'
   EXPIRE:         'page:expire'
+  AFTER_REMOVE:   'page:after-remove'
 
 fetch = (url, options = {}) ->
   url = new ComponentUrl url
@@ -143,7 +144,8 @@ changePage = (doc, options) ->
       nodesToBeKept.push(findNodesMatchingKeys(document.body, options.keep)...) if options.keep
       swapNodes(targetBody, nodesToBeKept, keep: true)
 
-    document.documentElement.replaceChild targetBody, document.body
+    existingBody = document.documentElement.replaceChild(targetBody, document.body)
+    triggerEvent(EVENTS.AFTER_REMOVE, existingBody)
     CSRFToken.update csrfToken if csrfToken?
     setAutofocusElement()
 
@@ -176,6 +178,7 @@ swapNodes = (targetBody, existingNodes, options) ->
       else
         targetNode = targetNode.cloneNode(true)
         existingNode.parentNode.replaceChild(targetNode, existingNode)
+        triggerEvent(EVENTS.AFTER_REMOVE, existingNode)
   return
 
 executeScriptTags = ->

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -134,8 +134,8 @@ changePage = (doc, options) ->
   triggerEvent EVENTS.BEFORE_UNLOAD
   document.title = title
 
-  swapNodes(targetBody, findNodes(document.body, '[data-turbolinks-temporary]'), keep: false)
   if options.change
+    swapNodes(targetBody, findNodes(document.body, '[data-turbolinks-temporary]'), keep: false)
     swapNodes(targetBody, findNodesMatchingKeys(document.body, options.change), keep: false)
   else
     unless options.flush

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -92,7 +92,7 @@ fetchReplacement = (url, options) ->
 
 fetchHistory = (cachedPage) ->
   xhr?.abort()
-  changePage createDocument(cachedPage.body.outerHTML), title: cachedPage.title, runScripts: false
+  changePage createDocument(cachedPage.body), title: cachedPage.title, runScripts: false
   progressBar?.done()
   recallScrollPosition cachedPage
   triggerEvent EVENTS.RESTORE
@@ -102,7 +102,7 @@ cacheCurrentPage = ->
 
   pageCache[currentStateUrl.absolute] =
     url:                      currentStateUrl.relative,
-    body:                     document.body,
+    body:                     document.body.outerHTML,
     title:                    document.title,
     positionY:                window.pageYOffset,
     positionX:                window.pageXOffset,

--- a/test/index.html
+++ b/test/index.html
@@ -5,8 +5,6 @@
   <title>Home</title>
   <script type="text/javascript" src="/js/turbolinks.js"></script>
   <script type="text/javascript">
-    Turbolinks.enableProgressBar();
-
     document.addEventListener("page:change", function() {
       console.log("page changed");
     });

--- a/test/javascript/iframe.html
+++ b/test/javascript/iframe.html
@@ -5,6 +5,12 @@
   <title>title</title>
   <meta content="authenticity_token" name="csrf-param">
   <meta content="token" name="csrf-token">
+  <script>
+    (function() { // workaround for bypassOnLoadPopstate
+      var originalSetTimeout = window.setTimeout;
+      window.setTimeout = function(fn) { return originalSetTimeout(fn, 0); };
+    })();
+  </script>
   <script src="/js/turbolinks.js"></script>
 </head>
 <body>

--- a/test/javascript/iframe2.html
+++ b/test/javascript/iframe2.html
@@ -5,6 +5,12 @@
   <title>title 2</title>
   <meta content="authenticity_token" name="csrf-param">
   <meta content="token2" name="csrf-token">
+  <script>
+    (function() { // workaround for bypassOnLoadPopstate
+      var originalSetTimeout = window.setTimeout;
+      window.setTimeout = function(fn) { return originalSetTimeout(fn, 0); };
+    })();
+  </script>
   <script src="/js/turbolinks.js"></script>
   <script>var headScript = true</script>
 </head>

--- a/test/javascript/turbolinks_replace_test.coffee
+++ b/test/javascript/turbolinks_replace_test.coffee
@@ -57,6 +57,7 @@ suite 'Turbolinks.replace()', ->
       assert.ok @$('body').hasAttribute('new-attribute')
       assert.notOk @$('#div')
       assert.equal @$('#permanent').textContent, 'permanent content'
+      assert.equal @$('#temporary').textContent, 'new content'
       assert.equal @document.title, 'new title'
       assert.equal @$('meta[name="csrf-token"]').getAttribute('content'), 'new-token'
       assert.notEqual @$('body'), body # body is replaced

--- a/test/javascript/turbolinks_replace_test.coffee
+++ b/test/javascript/turbolinks_replace_test.coffee
@@ -38,7 +38,7 @@ suite 'Turbolinks.replace()', ->
     body = @$('body')
     permanent = @$('#permanent')
     permanent.addEventListener 'click', -> done()
-    beforeUnloadFired = false
+    beforeUnloadFired = afterRemoveFired = false
     @document.addEventListener 'page:before-unload', =>
       assert.isUndefined @window.j
       assert.notOk @$('#new-div')
@@ -48,8 +48,14 @@ suite 'Turbolinks.replace()', ->
       assert.equal @document.title, 'title'
       assert.equal @$('body'), body
       beforeUnloadFired = true
+    @document.addEventListener 'page:after-remove', (event) =>
+      assert.isNull event.data.parentNode
+      assert.equal event.data, body
+      assert.notEqual permanent, event.data.querySelector('#permanent')
+      afterRemoveFired = true
     @document.addEventListener 'page:change', =>
       assert.ok beforeUnloadFired
+      assert.ok afterRemoveFired
       assert.equal @window.j, 1
       assert.isUndefined @window.headScript
       assert.isUndefined @window.bodyScriptEvalFalse
@@ -78,12 +84,19 @@ suite 'Turbolinks.replace()', ->
       </body>
       </html>
     """
-    beforeUnloadFired = false
+    body = @$('body')
+    beforeUnloadFired = afterRemoveFired = false
     @document.addEventListener 'page:before-unload', =>
       assert.equal @$('#permanent').textContent, 'permanent content'
       beforeUnloadFired = true
+    @document.addEventListener 'page:after-remove', (event) =>
+      assert.isNull event.data.parentNode
+      assert.equal event.data, body
+      assert.ok event.data.querySelector('#permanent')
+      afterRemoveFired = true
     @document.addEventListener 'page:change', =>
       assert.ok beforeUnloadFired
+      assert.ok afterRemoveFired
       assert.equal @$('#permanent').textContent, 'new content'
       done()
     @Turbolinks.replace(doc, flush: true)
@@ -101,14 +114,21 @@ suite 'Turbolinks.replace()', ->
       </body>
       </html>
     """
-    beforeUnloadFired = false
+    body = @$('body')
     div = @$('#div')
     div.addEventListener 'click', -> done()
+    beforeUnloadFired = afterRemoveFired = false
     @document.addEventListener 'page:before-unload', =>
       assert.equal @$('#div').textContent, 'div content'
       beforeUnloadFired = true
+    @document.addEventListener 'page:after-remove', (event) =>
+      assert.isNull event.data.parentNode
+      assert.equal event.data, body
+      assert.notEqual body, event.data.querySelector('#div')
+      afterRemoveFired = true
     @document.addEventListener 'page:change', =>
       assert.ok beforeUnloadFired
+      assert.ok afterRemoveFired
       assert.equal @$('#div').textContent, 'div content'
       assert.equal @$('#div'), div # :keep nodes are transferred
       @$('#div').click() # event listeners on :keep nodes should not be lost
@@ -137,6 +157,7 @@ suite 'Turbolinks.replace()', ->
     """
     body = @$('body')
     change = @$('#change')
+    temporary = @$('#temporary')
     beforeUnloadFired = false
     @document.addEventListener 'page:before-unload', =>
       assert.equal @window.i, 1
@@ -145,8 +166,13 @@ suite 'Turbolinks.replace()', ->
       assert.equal @$('#temporary').textContent, 'temporary content'
       assert.equal @document.title, 'title'
       beforeUnloadFired = true
+    afterRemoveNodes = [@$('#temporary'), change, @$('[id="change:key"]')]
+    @document.addEventListener 'page:after-remove', (event) =>
+      assert.isNull event.data.parentNode
+      assert.equal event.data, afterRemoveNodes.shift()
     @document.addEventListener 'page:change', =>
       assert.ok beforeUnloadFired
+      assert.equal afterRemoveNodes.length, 0
       assert.equal @window.i, 2
       assert.isUndefined @window.bodyScript
       assert.isUndefined @window.headScript
@@ -159,6 +185,7 @@ suite 'Turbolinks.replace()', ->
       assert.equal @$('#permanent').textContent, 'permanent content'
       assert.equal @$('meta[name="csrf-token"]').getAttribute('content'), 'token'
       assert.equal @document.title, 'new title'
+      assert.notEqual @$('#temporary'), temporary # temporary nodes are cloned
       assert.notEqual @$('#change'), change # changed nodes are cloned
       assert.equal @$('body'), body
       done()

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -135,6 +135,7 @@ suite 'Turbolinks.visit()', ->
     @document.addEventListener 'page:load', =>
       load += 1
       if load is 1
+        assert.ok @$('body').hasAttribute('new-attribute')
         assert.equal @document.title, 'title 2'
         assert.equal @$('#permanent'), permanent
         setTimeout (=> @Turbolinks.visit('iframe.html')), 0
@@ -147,6 +148,7 @@ suite 'Turbolinks.visit()', ->
     @document.addEventListener 'page:restore', =>
       assert.equal load, 1
       assert.equal @window.i, 1
+      assert.notOk @$('body').hasAttribute('new-attribute')
       assert.equal @document.title, 'title'
       assert.equal @$('#permanent'), permanent
       restoreCalled = true


### PR DESCRIPTION
As explained in #484, Turbolinks + jQuery is prone to memory leaks because Turbolinks removes nodes from the DOM without using `jQuery.fn.remove`, leaving jQuery with pointers to event handlers (for these removed DOM trees) in memory.

For example, you can see below how jQuery 2.0 stores event handlers internally:

![thibaut customers new shopify 2015-03-07 09-25-23](https://cloud.githubusercontent.com/assets/17579/6547912/c5016c36-c5bd-11e4-9e67-f0a7bc2bdbe3.png)

DOM elements on which an event handler was attached with jQuery (`jQuery.fn.on`) have a hidden property which contains an ID which jQuery uses internally to keep track of event handlers.

If we remove `#new_customer` from the DOM without using `jQuery.fn.remove`, the object on the last line and functions it points to are never garbage-collected.

This PR adds a `page:after-remove` event triggered after a node is removed from the DOM, to allow user scripts to do some clean up.

PS: it appears Basecamp is already cleaning up jQuery events between page visits, as it isn't leaking memory on every page, unlike Shopify was before we implemented this fix. I did find, however, a leak on pages which contains a wysiwyg editor. You can see below the result of navigating back & forth between `/documents/new` and another page: (+2 objects every time)

![storefront editor new document 2015-03-07 09-55-40](https://cloud.githubusercontent.com/assets/17579/6547968/77a793be-c5bf-11e4-8e58-0f0d8357aa7c.png)

cc @dhh @DrewMartin @reed 