### PR TITLE
redirect_to must return a truthy value

### DIFF
--- a/lib/turbolinks/redirection.rb
+++ b/lib/turbolinks/redirection.rb
@@ -6,11 +6,13 @@ module Turbolinks
     def redirect_to(url = {}, response_status = {})
       turbolinks, options = _extract_turbolinks_options!(response_status)
 
-      super(url, response_status)
+      value = super(url, response_status)
 
       if turbolinks || (turbolinks != false && request.xhr? && !request.get?)
         _perform_turbolinks_response "Turbolinks.visit('#{location}'#{_turbolinks_js_options(options)});"
       end
+
+      value
     end
 
     def render(*args, &block)

--- a/test/turbolinks/redirection_test.rb
+++ b/test/turbolinks/redirection_test.rb
@@ -5,6 +5,11 @@ class RedirectController < ActionController::Base
     redirect_to 'http://example.com'
   end
 
+  def redirect_to_and_return
+    redirect_to '/path' and return
+    raise "redirect_to should return a truthy value"
+  end
+
   def redirect_to_url_string_with_turbolinks
     redirect_to 'http://example.com', turbolinks: true
   end
@@ -74,6 +79,11 @@ end
 
 class RedirectionTest < ActionController::TestCase
   tests RedirectController
+
+  def test_redirect_to_returns_a_truthy_value
+    get :redirect_to_and_return
+    assert_redirected_to '/path'
+  end
 
   def test_redirect_to_url_string_with_turbolinks
     get :redirect_to_url_string_with_turbolinks


### PR DESCRIPTION
## Problem

`redirect_to(...) and return` is a common idiom. It's even recommended in [the error message for `DoubleRenderError`](https://github.com/rails/rails/blob/f6d9b689977c1dca1ed7f149f704d1b4344cd691/actionpack/lib/abstract_controller/rendering.rb#L9)

The idiom relies on `redirect_to` returning a truthy value, but since Turbolinks' `redirect_to` ends in a conditional, it can return `nil`.

## Solution

Return the original return value of the `super` call.