### PR TITLE
Allow pages to say they don't want to be cached

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -97,6 +97,8 @@ fetchHistory = (cachedPage) ->
   triggerEvent EVENTS.RESTORE
 
 cacheCurrentPage = ->
+  return if document.querySelector('[data-no-turbolinks-cache]')?
+  
   currentStateUrl = new ComponentUrl currentState.url
 
   pageCache[currentStateUrl.absolute] =


### PR DESCRIPTION
Add a data-no-turbolinks-cache attribute to any tag, and the entire page won't be cached.

This is useful in situations where the page contains elements such as video tags that need to be rendered using video.js, which aren't compatible with being stored in the cache.

You could use data-no-turbolink to prevent links on the page from using turbolinks, but that's not really what we're after.