### PR TITLE
Prefer using prepend instead of alias_method_chain when it is defined

### DIFF
--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -45,7 +45,11 @@ module Turbolinks
 
       ActiveSupport.on_load(:action_view) do
         (ActionView::RoutingUrlFor rescue ActionView::Helpers::UrlHelper).module_eval do
-          include XHRUrlFor
+          if defined?(prepend) && Rails.version >= '4'
+            prepend XHRUrlFor
+          else
+            include LegacyXHRUrlFor
+          end
         end
       end
     end

--- a/lib/turbolinks/xhr_url_for.rb
+++ b/lib/turbolinks/xhr_url_for.rb
@@ -3,6 +3,14 @@ module Turbolinks
   # option by using the X-XHR-Referer request header instead of the standard Referer
   # request header.
   module XHRUrlFor
+    def url_for(options = {})
+      options = (controller.request.headers["X-XHR-Referer"] || options) if options == :back
+      super
+    end
+  end
+
+  # TODO: Remove me when support for Ruby < 2 && Rails < 4 is dropped
+  module LegacyXHRUrlFor
     def self.included(base)
       base.alias_method_chain :url_for, :xhr_referer
     end


### PR DESCRIPTION
After reviewing [deprecation warnings for `alias_method_chain` in the Rails test suite](https://travis-ci.org/rails/rails/jobs/55691861#L422), @chancancode and I were able to trace this [back to the Turbolinks gem](https://github.com/rails/turbolinks/blob/master/lib/turbolinks/xhr_url_for.rb#L7) as at least one of the sources of this error. `XHRUrlFor` is using `alias_method_chain` to modify `url_for`.

The method was deprecated in Rails with [this commit](https://github.com/rails/rails/commit/a982a42d) and the warning advises the use of `prepend` instead.

In this commit, we move the exist implementation of `XHRUrlFor` to `LegacyXHRUrlFor` and only use it if `prepend` is not defined.

/cc @kirs