### PR TITLE
Render XHR+GET requests with turbolinks by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ redirect_to path, flush: true
 ```
 
 ```ruby
- # Render with Turbolinks when the request is XHR and not GET.
+ # Render with Turbolinks when the request is XHR.
  # Refresh any `data-turbolinks-temporary` nodes and nodes with `id` matching `new_comment`.
 render view, change: 'new_comment'
 

--- a/lib/turbolinks/redirection.rb
+++ b/lib/turbolinks/redirection.rb
@@ -21,7 +21,7 @@ module Turbolinks
 
       super(*args, render_options, &block)
 
-      if turbolinks || (turbolinks != false && options.size > 0 && request.xhr? && !request.get?)
+      if turbolinks || (turbolinks != false && options.size > 0 && request.xhr?)
         _perform_turbolinks_response "Turbolinks.replace('#{view_context.j(response.body)}'#{_turbolinks_js_options(options)});"
       end
 

--- a/test/turbolinks/render_test.rb
+++ b/test/turbolinks/render_test.rb
@@ -118,10 +118,16 @@ class RenderTest < ActionController::TestCase
     assert_turbolinks_replace 'content', "{ keep: ['foo', 'bar'] }"
   end
 
-  def test_render_via_xhr_and_get_with_change_option_does_normal_render
+  def test_simple_render_via_xhr_and_get_does_normal_render
+    @request.env['HTTP_ACCEPT'] = Mime::HTML
+    xhr :get, :simple_render
+    assert_normal_render 'content'
+  end
+
+  def test_render_via_xhr_and_get_with_change_option_renders_via_turbolinks
     @request.env['HTTP_ACCEPT'] = Mime::HTML
     xhr :get, :render_with_single_change_option
-    assert_normal_render 'content'
+    assert_turbolinks_replace 'content', "{ change: ['foo'] }"
   end
 
   def test_render_via_post_and_not_xhr_with_keep_option_does_normal_render


### PR DESCRIPTION
… when `:change`, `:keep` or `:flush` is passed to `render`.

Fix #505.

cc @dhh @qq99