### PR TITLE
Add ability to opt out of Turbolinks in certain controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,11 @@
 
     *Thibaut Courouble*, *Kevin Hughes*
 
+*   Add ability to opt out of Turbolinks in certain controllers by setting `config.auto_include_turbolinks` to `false` in `application.rb` and including `Turbolinks::Controller` in the controllers where Turbolinks is used.
+
+    *Thibaut Courouble*
+
+
 ## Turbolinks 2.5.3 (December 8, 2014)
 
 *   Prevent the progress bar from filling the entire screen in older versions of Safari.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Also, Turbolinks is installed as the last click handler for links. So if you ins
 
 Note: in Turbolinks 3.0, the default behavior of `redirect_to` is to redirect via Turbolinks (`Turbolinks.visit` response) for XHR + non-GET requests. You can opt-out of this behavior by passing `turbolinks: false` to `redirect_to`.
 
+By default, Turbolinks includes itself in `ActionController::Base`. To opt out of the Turbolinks features in certain controllers, set `config.auto_include_turbolinks` to `false` in `application.rb` and include `Turbolinks::Controller` in the controllers where you use Turbolinks.
+
 
 jquery.turbolinks
 -----------------

--- a/test/turbolinks/engine_test.rb
+++ b/test/turbolinks/engine_test.rb
@@ -1,0 +1,7 @@
+require_relative 'test_helper'
+
+class EngineTest < ActiveSupport::TestCase
+  def test_does_not_include_itself_in_action_controller_base_when_auto_include_turbolinks_is_false
+    refute ActionController::Base.included_modules.any? { |m| m.name.include?('Turbolinks') }
+  end
+end

--- a/test/turbolinks/redirection_test.rb
+++ b/test/turbolinks/redirection_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class RedirectController < ActionController::Base
+class RedirectController < TestController
   def redirect_to_url_string
     redirect_to 'http://example.com'
   end

--- a/test/turbolinks/render_test.rb
+++ b/test/turbolinks/render_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class RenderController < ActionController::Base
+class RenderController < TestController
   require 'action_view/testing/resolvers'
   self.view_paths = ActionView::FixtureResolver.new('render/action.html.erb' => 'content')
 

--- a/test/turbolinks/test_helper.rb
+++ b/test/turbolinks/test_helper.rb
@@ -12,6 +12,7 @@ class TestApplication < Rails::Application
   config.secret_token = Digest::SHA1.hexdigest(Time.now.to_s)
   config.secret_key_base = SecureRandom.hex
   config.eager_load = false
+  config.auto_include_turbolinks = false
 
   initialize!
 
@@ -22,11 +23,12 @@ class TestApplication < Rails::Application
   end
 end
 
-module ActionController
-  class Base
-    extend AbstractController::Railties::RoutesHelpers.with(TestApplication.routes)
-  end
+class TestController < ActionController::Base
+  extend AbstractController::Railties::RoutesHelpers.with(TestApplication.routes)
+  include Turbolinks::Controller
+end
 
+module ActionController
   class TestCase
     setup do
       @routes = TestApplication.routes

--- a/test/turbolinks/turbolinks_test.rb
+++ b/test/turbolinks/turbolinks_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class TurbolinksController < ActionController::Base
+class TurbolinksController < TestController
   def simple_action
     render text: ' '
   end


### PR DESCRIPTION
This lets applications override which controllers Turbolinks should include itself into (instead of the default `ActionController::Base`) — useful for disabling the Turbolinks callbacks that add data to the user session and cookies in controllers that don't use `turbolinks.coffee`.

We have this use case in Shopify where we run two different sets of controllers (shop area and admin area) side by side, but only use Turbolinks in one of those.

Original Turbograft PR: https://github.com/Shopify/turbograft/pull/21

cc @arthurnn @rafaelfranca 