### PR TITLE
Add data-turbolinks-cache="false" attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,9 @@
 
     *Thibaut Courouble*
 
+*   Add ability to remove only certain elements from a cached page, before restoring it, by specifying `data-turbolinks-cache="false"` on those elements.
+
+    *Christophe Maximin*
 
 ## Turbolinks 2.5.3 (December 8, 2014)
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ DOM transformations that are idempotent are best. If you have transformations th
 $(document).on("ready page:load", nonIdempotentFunction);
 ```
 
+To remove some elements from the DOM before displaying a page again from the cache, like a flash notice, you can give them the attribute `data-turbolinks-cache="false"`
+
 Transition Cache: A Speed Boost
 -------------------------------
 

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -92,7 +92,9 @@ fetchReplacement = (url, options) ->
 
 fetchHistory = (cachedPage, options = {}) ->
   xhr?.abort()
-  changePage createDocument(cachedPage.body), title: cachedPage.title, runScripts: false
+  newDocument = createDocument(cachedPage.body)
+  node.parentNode.removeChild(node) for node in findNodes(newDocument, '[data-turbolinks-cache="false"]')
+  changePage newDocument, title: cachedPage.title, runScripts: false
   progressBar?.done()
   updateScrollPosition(options.scroll)
   triggerEvent EVENTS.RESTORE

--- a/test/javascript/iframe.html
+++ b/test/javascript/iframe.html
@@ -18,6 +18,7 @@
   <div id="change:key">change content</div>
   <div id="permanent" data-turbolinks-permanent>permanent content</div>
   <div id="temporary" data-turbolinks-temporary>temporary content</div>
+  <div id="ignored-from-cache" data-turbolinks-cache="false">content ignored from cache</div>
   <script>window.i = window.i || 0; window.i++;</script>
   <script data-turbolinks-eval="always">window.k = window.k || 0; window.k++;</script>
 </body>

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -162,6 +162,7 @@ suite 'Turbolinks.visit()', ->
         assert.equal @window.i, 2
         assert.equal @document.title, 'title'
         assert.equal @$('#permanent'), permanent
+        assert.ok @$('#ignored-from-cache')
         @$('#permanent').click() # event listeners on permanent nodes should not be lost
     @document.addEventListener 'page:restore', =>
       assert.equal load, 1
@@ -169,6 +170,7 @@ suite 'Turbolinks.visit()', ->
       assert.notOk @$('body').hasAttribute('new-attribute')
       assert.equal @document.title, 'title'
       assert.equal @$('#permanent'), permanent
+      assert.notOk @$('#ignored-from-cache')
       restoreCalled = true
     @Turbolinks.enableTransitionCache()
     @Turbolinks.visit('iframe2.html')


### PR DESCRIPTION
Adds a `data-ignore-from-transition-cache` attribute, which will remove the concerned elements from the DOM before restoring the page. It's a softer version of `data-no-transition-cache`.

This commit also contains tests and documentation.

This is especially useful for flash notifications, in the following scenario:
- User loads /posts and clicks on "new post"
- User submits form and is redirected to /posts which displays a flash notification "Post created!"
- User loads [any other page]
- User clicks on "my posts" and **before** /posts is actually loaded, the cache **with the flash notice** will be displayed until the page is loaded
- User = possibly confused

While `data-no-transition-cache` is useful to throw out the whole page, it's unnecessary in cases like that, where  `data-ignore-from-transition-cache` would make more sense while preserving the website's swift display.