### PR TITLE
Scroll improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,11 @@
 
     *Thibaut Courouble*
 
+*   Add ability to prevent `Turbolinks.visit` from resetting the scroll position.
+
+    ```coffeescript
+    Turbolinks.visit url, scroll: false
+    ```
 
 ## Turbolinks 2.5.3 (December 8, 2014)
 

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -30,12 +30,12 @@ fetch = (url, options = {}) ->
   progressBar?.start()
 
   if transitionCacheEnabled and cachedPage = transitionCacheFor(url.absolute)
-    fetchHistory cachedPage
+    fetchHistory cachedPage, recallScrollPosition: false
     options.showProgressBar = false
-    fetchReplacement url, options
   else
     options.onLoadFunction = resetScrollPosition unless options.change
-    fetchReplacement url, options
+
+  fetchReplacement url, options
 
 transitionCacheFor = (url) ->
   cachedPage = pageCache[url]
@@ -89,11 +89,14 @@ fetchReplacement = (url, options) ->
 
   xhr.send()
 
-fetchHistory = (cachedPage) ->
+fetchHistory = (cachedPage, options) ->
   xhr?.abort()
   changePage createDocument(cachedPage.body), title: cachedPage.title, runScripts: false
   progressBar?.done()
-  recallScrollPosition cachedPage
+  if options.recallScrollPosition
+    recallScrollPosition cachedPage
+  else
+    resetScrollPosition()
   triggerEvent EVENTS.RESTORE
 
 cacheCurrentPage = ->
@@ -587,7 +590,7 @@ onHistoryChange = (event) ->
   if event.state?.turbolinks && event.state.url != currentState.url
     if cachedPage = pageCache[(new ComponentUrl(event.state.url)).absolute]
       cacheCurrentPage()
-      fetchHistory cachedPage
+      fetchHistory cachedPage, recallScrollPosition: true
     else
       visit event.target.location.href
 

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -34,7 +34,7 @@ fetch = (url, options = {}) ->
     options.showProgressBar = false
     fetchReplacement url, options
   else
-    options.onLoadFunction = resetScrollPosition
+    options.onLoadFunction = resetScrollPosition unless options.change
     fetchReplacement url, options
 
 transitionCacheFor = (url) ->

--- a/test/javascript/iframe.html
+++ b/test/javascript/iframe.html
@@ -7,6 +7,10 @@
   <meta content="token" name="csrf-token">
   <script src="/js/jquery.js"></script>
   <script src="/js/turbolinks.js"></script>
+  <style>
+    html { overflow: scroll; }
+    body:before { content: ''; display: block; width: 1000px; height: 1000px; }
+  </style>
 </head>
 <body>
   <div id="div">div content</div>

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -221,15 +221,21 @@ suite 'Turbolinks.visit()', ->
   # Temporary until mocha fixes skip() in async tests or PhantomJS fixes scrolling inside iframes.
   return if navigator.userAgent.indexOf('PhantomJS') != -1
 
-  test "scrolls to top by default", (done) ->
+  test "scrolls to target or top by default", (done) ->
     @window.scrollTo(42, 42)
     assert.equal @window.pageXOffset, 42
     assert.equal @window.pageYOffset, 42
+    load = 0
     @document.addEventListener 'page:load', =>
-      assert.equal @window.pageXOffset, 0
-      assert.equal @window.pageYOffset, 0
-      done()
-    @Turbolinks.visit('iframe2.html')
+      load += 1
+      if load is 1
+        assert.closeTo @window.pageYOffset, @$('#change').offsetTop, 100
+        setTimeout (=> @Turbolinks.visit('iframe.html', scroll: null)), 0
+      else if load is 2
+        assert.equal @window.pageXOffset, 0
+        assert.equal @window.pageYOffset, 0
+        done()
+    @Turbolinks.visit('iframe2.html#change', scroll: undefined)
 
   test "restores scroll position on history.back() cache hit", (done) ->
     change = 0
@@ -288,3 +294,11 @@ suite 'Turbolinks.visit()', ->
       assert.equal @window.pageYOffset, 42
       done()
     @Turbolinks.visit('iframe2.html', change: ['change'])
+
+  test "doesn't scroll to top with scroll: false", (done) ->
+    @window.scrollTo(42, 42)
+    @document.addEventListener 'page:load', =>
+      assert.equal @window.pageXOffset, 42
+      assert.equal @window.pageYOffset, 42
+      done()
+    @Turbolinks.visit('iframe2.html', scroll: false)

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -258,3 +258,11 @@ suite 'Turbolinks.visit()', ->
     @window.scrollTo(42, 42)
     @Turbolinks.pagesCached(0)
     @Turbolinks.visit('iframe2.html')
+
+  test "doesn't scroll to top with :change", (done) ->
+    @window.scrollTo(42, 42)
+    @document.addEventListener 'page:load', =>
+      assert.equal @window.pageXOffset, 42
+      assert.equal @window.pageYOffset, 42
+      done()
+    @Turbolinks.visit('iframe2.html', change: ['change'])

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -259,6 +259,28 @@ suite 'Turbolinks.visit()', ->
     @Turbolinks.pagesCached(0)
     @Turbolinks.visit('iframe2.html')
 
+  test "scrolls to top on transition cache hit", (done) ->
+    load = 0
+    restoreCalled = false
+    @document.addEventListener 'page:load', =>
+      load += 1
+      if load is 1
+        @window.scrollTo(8, 8)
+        setTimeout (=> @Turbolinks.visit('iframe.html')), 0
+      else if load is 2
+        assert.ok restoreCalled
+        assert.equal @window.pageXOffset, 16
+        assert.equal @window.pageYOffset, 16
+        done()
+    @document.addEventListener 'page:restore', =>
+      assert.equal @window.pageXOffset, 0
+      assert.equal @window.pageYOffset, 0
+      @window.scrollTo(16, 16)
+      restoreCalled = true
+    @window.scrollTo(4, 4)
+    @Turbolinks.enableTransitionCache()
+    @Turbolinks.visit('iframe2.html')
+
   test "doesn't scroll to top with :change", (done) ->
     @window.scrollTo(42, 42)
     @document.addEventListener 'page:load', =>


### PR DESCRIPTION
- Add scrolling tests. Unfortunately I couldn't figure out a way to make these work in PhantomJS 2.0 (it seems scrolling iframes worked in 1.9, but our test suite requires 2.0)

- Don't scroll to top on partial replacement (https://github.com/rails/turbolinks/pull/291#issuecomment-98488300 cc @drewhamlett)

- Don't restore scroll position on transition cache hit (which IMO is the expected behavior on a `Turbolinks.visit()` / navigation click)

@reed: works for you?