### PR TITLE
Attach affected nodes to lifecycle events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@
     Turbolinks.visit url, scroll: false
     ```
 
-*   Attach affected nodes to the `page:before-unload` and `page:change` events (in `event.data`).
+*   Attach affected nodes to the `page:before-unload`, `page:change` and `page:load` events (in `event.data`).
 
     *Thibaut Courouble*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@
     Turbolinks.visit url, scroll: false
     ```
 
-*   Attach affected nodes to the `page:before-unload` event (in `event.data`).
+*   Attach affected nodes to the `page:before-unload` and `page:change` events (in `event.data`).
 
     *Thibaut Courouble*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,11 @@
     Turbolinks.visit url, scroll: false
     ```
 
+*   Attach affected nodes to the `page:before-unload` event (in `event.data`).
+
+    *Thibaut Courouble*
+
+
 ## Turbolinks 2.5.3 (December 8, 2014)
 
 *   Prevent the progress bar from filling the entire screen in older versions of Safari.

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -67,12 +67,12 @@ fetchReplacement = (url, options) ->
     if doc = processResponse()
       reflectNewUrl url
       reflectRedirectedUrl()
-      changePage doc, options
+      loadedNodes = changePage doc, options
       if options.showProgressBar
         progressBar?.done()
       manuallyTriggerHashChangeForFirefox()
       updateScrollPosition(options.scroll)
-      triggerEvent EVENTS.LOAD
+      triggerEvent EVENTS.LOAD, loadedNodes
     else
       progressBar?.done()
       document.location.href = crossOriginRedirect() or url.absolute
@@ -125,7 +125,8 @@ constrainPageCacheTo = (limit) ->
     delete pageCache[key]
 
 replace = (html, options = {}) ->
-  changePage createDocument(html), options
+  loadedNodes = changePage createDocument(html), options
+  triggerEvent EVENTS.LOAD, loadedNodes
 
 changePage = (doc, options) ->
   [title, targetBody, csrfToken] = extractTitleAndBody(doc)
@@ -161,6 +162,7 @@ changePage = (doc, options) ->
 
   triggerEvent EVENTS.CHANGE, changedNodes
   triggerEvent EVENTS.UPDATE
+  return changedNodes
 
 findNodes = (body, selector) ->
   Array::slice.apply(body.querySelectorAll(selector))

--- a/test/javascript/turbolinks_replace_test.coffee
+++ b/test/javascript/turbolinks_replace_test.coffee
@@ -53,9 +53,10 @@ suite 'Turbolinks.replace()', ->
       assert.equal event.data, body
       assert.notEqual permanent, event.data.querySelector('#permanent')
       afterRemoveFired = true
-    @document.addEventListener 'page:change', =>
+    @document.addEventListener 'page:load', (event) =>
       assert.ok beforeUnloadFired
       assert.ok afterRemoveFired
+      assert.deepEqual event.data, [@document.body]
       assert.equal @window.j, 1
       assert.isUndefined @window.headScript
       assert.isUndefined @window.bodyScriptEvalFalse
@@ -170,9 +171,10 @@ suite 'Turbolinks.replace()', ->
     @document.addEventListener 'page:after-remove', (event) =>
       assert.isNull event.data.parentNode
       assert.equal event.data, afterRemoveNodes.shift()
-    @document.addEventListener 'page:change', =>
+    @document.addEventListener 'page:load', (event) =>
       assert.ok beforeUnloadFired
       assert.equal afterRemoveNodes.length, 0
+      assert.deepEqual event.data, [@$('#temporary'), @$('#change'), @$('[id="change:key"]')]
       assert.equal @window.i, 2 # scripts are re-run
       assert.isUndefined @window.bodyScript
       assert.isUndefined @window.headScript

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -24,7 +24,7 @@ suite 'Turbolinks.visit()', ->
     body = @$('body')
     permanent = @$('#permanent')
     permanent.addEventListener 'click', -> done()
-    pageReceivedFired = beforeUnloadFired = afterRemoveFired = false
+    pageReceivedFired = beforeUnloadFired = afterRemoveFired = pageChangeFired = false
     @document.addEventListener 'page:receive', =>
       state = turbolinks: true, url: "#{location.protocol}//#{location.host}/javascript/iframe.html"
       assert.deepEqual @history.state, state
@@ -44,10 +44,14 @@ suite 'Turbolinks.visit()', ->
       assert.equal event.data, body
       assert.notEqual permanent, event.data.querySelector('#permanent')
       afterRemoveFired = true
+    @document.addEventListener 'page:change', (event) =>
+      assert.deepEqual event.data, [@document.body]
+      pageChangeFired = true
     @document.addEventListener 'page:load', =>
       assert.ok pageReceivedFired
       assert.ok beforeUnloadFired
       assert.ok afterRemoveFired
+      assert.ok pageChangeFired
       assert.equal @window.i, 1
       assert.equal @window.j, 1
       assert.isUndefined @window.headScript
@@ -74,7 +78,7 @@ suite 'Turbolinks.visit()', ->
     change = @$('#change')
     change2 = @$('[id="change:key"]')
     temporary = @$('#temporary')
-    beforeUnloadFired = false
+    beforeUnloadFired = pageChangeFired = false
     @document.addEventListener 'page:before-unload', (event) =>
       assert.deepEqual event.data, [temporary, change, change2]
       assert.equal @window.i, 1
@@ -83,8 +87,12 @@ suite 'Turbolinks.visit()', ->
       assert.equal @$('#temporary').textContent, 'temporary content'
       assert.equal @document.title, 'title'
       beforeUnloadFired = true
+    @document.addEventListener 'page:change', (event) =>
+      assert.deepEqual event.data, [@$('#temporary'), @$('#change'), @$('[id="change:key"]')]
+      pageChangeFired = true
     @document.addEventListener 'page:load', =>
       assert.ok beforeUnloadFired
+      assert.ok pageChangeFired
       assert.equal @window.i, 2
       assert.isUndefined @window.j
       assert.isUndefined @window.headScript

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -47,11 +47,12 @@ suite 'Turbolinks.visit()', ->
     @document.addEventListener 'page:change', (event) =>
       assert.deepEqual event.data, [@document.body]
       pageChangeFired = true
-    @document.addEventListener 'page:load', =>
+    @document.addEventListener 'page:load', (event) =>
       assert.ok pageReceivedFired
       assert.ok beforeUnloadFired
       assert.ok afterRemoveFired
       assert.ok pageChangeFired
+      assert.deepEqual event.data, [@document.body]
       assert.equal @window.i, 1
       assert.equal @window.j, 1
       assert.isUndefined @window.headScript
@@ -90,9 +91,10 @@ suite 'Turbolinks.visit()', ->
     @document.addEventListener 'page:change', (event) =>
       assert.deepEqual event.data, [@$('#temporary'), @$('#change'), @$('[id="change:key"]')]
       pageChangeFired = true
-    @document.addEventListener 'page:load', =>
+    @document.addEventListener 'page:load', (event) =>
       assert.ok beforeUnloadFired
       assert.ok pageChangeFired
+      assert.deepEqual event.data, [@$('#temporary'), @$('#change'), @$('[id="change:key"]')]
       assert.equal @window.i, 2
       assert.isUndefined @window.j
       assert.isUndefined @window.headScript

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -29,8 +29,9 @@ suite 'Turbolinks.visit()', ->
       state = turbolinks: true, url: "#{location.protocol}//#{location.host}/javascript/iframe.html"
       assert.deepEqual @history.state, state
       pageReceivedFired = true
-    @document.addEventListener 'page:before-unload', =>
+    @document.addEventListener 'page:before-unload', (event) =>
       assert.isUndefined @window.j
+      assert.deepEqual event.data, [body]
       assert.notOk @$('#new-div')
       assert.notOk @$('body').hasAttribute('new-attribute')
       assert.ok @$('#div')
@@ -71,9 +72,11 @@ suite 'Turbolinks.visit()', ->
   test "successful with :change", (done) ->
     body = @$('body')
     change = @$('#change')
+    change2 = @$('[id="change:key"]')
     temporary = @$('#temporary')
     beforeUnloadFired = false
-    @document.addEventListener 'page:before-unload', =>
+    @document.addEventListener 'page:before-unload', (event) =>
+      assert.deepEqual event.data, [temporary, change, change2]
       assert.equal @window.i, 1
       assert.equal @$('#change').textContent, 'change content'
       assert.equal @$('[id="change:key"]').textContent, 'change content'


### PR DESCRIPTION
**Problem:**

- 
  ```coffeescript
  $(document).on 'page:update', ->
    $(document.body).on('click', '.selector', fn)
    $(document.body).find('.selector').click(fn2)
  ```
  … attaches duplicate event handlers on every partial replacement (since the body didn't change).

  Same with `page:load`.

- `Turbolinks.replace()` doesn't trigger the `page:load` event, even though it's inserting new elements into the DOM (which people may want to transform the same way they do on normal page loads).

**What this PR does:**

- Attach affected nodes to the `page:before-unload`, `page:change` and `page:load` events.

  The above snippet could be rewritten as follow:

  ```coffeescript
  $(document).on 'page:update', (event) ->
    $(document.body).on('click', '.selector', fn) if event.data[0] == document.body
    $(event.data).find('.selector').click(fn2)
  ```

- Fire `page:load` in `Turbolinks.replace()` (passing the loaded nodes).

Docs soon.

cc @dhh