### PR TITLE
Allow using title option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Turbolinks (master)
 
+*   `Turbolinks.visit` and `Turbolinks.replace` accept a `title` option.
+
+    *Guillaume Malette*
+
+    ```coffeescript
+    # Specifying a title will overwrite the title
+    Turbolinks.visit(url, title: 'New title')
+
+    # Using `false` as a title will prevent Turbolinks from changing the title
+    Turbolinks.replace(html, title: false)
+    ```
+
 *   Noscript tags are no longer removed from body on page changes.
 
     *René Hansen*

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -129,8 +129,9 @@ replace = (html, options = {}) ->
   triggerEvent EVENTS.LOAD, loadedNodes
 
 changePage = (doc, options) ->
-  [title, targetBody, csrfToken] = extractTitleAndBody(doc)
-  title ?= options.title
+  title = options.title
+  [extractedTitle, targetBody, csrfToken] = extractTitleAndBody(doc)
+  title ?= extractedTitle
   currentBody = document.body
 
   if options.change
@@ -140,7 +141,7 @@ changePage = (doc, options) ->
     nodesToChange = [currentBody]
 
   triggerEvent EVENTS.BEFORE_UNLOAD, nodesToChange
-  document.title = title
+  document.title = title if title != false
 
   if options.change
     changedNodes = swapNodes(targetBody, nodesToChange, keep: false)

--- a/test/javascript/turbolinks_replace_test.coffee
+++ b/test/javascript/turbolinks_replace_test.coffee
@@ -243,3 +243,41 @@ suite 'Turbolinks.replace()', ->
       assert.notEqual @$('#temporary'), temporary # temporary nodes are cloned when found
       done()
     @Turbolinks.replace(html, change: ['div'])
+
+  test "with :title set to a value replaces the title with the value", (done) ->
+    doc = """
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <title>new title</title>
+      </head>
+      <body new-attribute>
+        <div id="new-div"></div>
+      </body>
+      </html>
+    """
+    body = @$('body')
+    permanent = @$('#permanent')
+    @document.addEventListener 'page:load', (event) =>
+      assert.equal @document.title, 'specified title'
+      done()
+    @Turbolinks.replace(doc, title: 'specified title')
+
+  test "with :title set to false doesn't replace the title", (done) ->
+    doc = """
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <title>new title</title>
+      </head>
+      <body new-attribute>
+        <div id="new-div"></div>
+      </body>
+      </html>
+    """
+    body = @$('body')
+    permanent = @$('#permanent')
+    @document.addEventListener 'page:load', (event) =>
+      assert.equal @document.title, 'title'
+      done()
+    @Turbolinks.replace(doc, title: false)

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -231,6 +231,19 @@ suite 'Turbolinks.visit()', ->
       setTimeout (-> done?()), 0
     @Turbolinks.visit('iframe2.html')
 
+  test "with :title set to a value replaces the title with the value", (done) ->
+    @document.addEventListener 'page:load', =>
+      assert.equal @document.title, 'specified title'
+      done()
+    @Turbolinks.visit('iframe2.html', title: 'specified title')
+
+  test "with :title set to false doesn't replace the title", (done) ->
+    @document.title = 'test'
+    @document.addEventListener 'page:load', =>
+      assert.equal @document.title, 'test'
+      done()
+    @Turbolinks.visit('iframe2.html', title: false)
+
   # Temporary until mocha fixes skip() in async tests or PhantomJS fixes scrolling inside iframes.
   return if navigator.userAgent.indexOf('PhantomJS') != -1
 


### PR DESCRIPTION
The `replace` and `visit` functions allow passing in options, one of which is `title`. The problem is that the title is will only be used if the new page doesn't specify a new title. My app changes the title of the page to add "badges" and capture the user's attention, e.g. `(1) My App`

```js
title = document.title
Turbolinks.replace(body, {container: 'main-feed'})
document.title
```

With this PR, I can only do 

```js
Turbolinks.replace(body, {container: 'main-feed', title: false})
```

@Thibaut this is what I was talking about