### PR TITLE
Prevent `Turbolinks.visit` to the same-as-current cached page with `change` option from scrolling up.

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -29,7 +29,7 @@ fetch = (url, options = {}) ->
   cacheCurrentPage()
   progressBar?.start()
 
-  if transitionCacheEnabled and cachedPage = transitionCacheFor(url.absolute)
+  if transitionCacheEnabled and !options.change and cachedPage = transitionCacheFor(url.absolute)
     fetchHistory cachedPage
     options.showProgressBar = false
     options.scroll = false

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -173,6 +173,16 @@ suite 'Turbolinks.visit()', ->
     @Turbolinks.enableTransitionCache()
     @Turbolinks.visit('iframe2.html')
 
+  test "with :change, skips transition cache", (done) ->
+    restoreCalled = false
+    @document.addEventListener 'page:restore', =>
+      restoreCalled = true
+    @document.addEventListener 'page:load', =>
+      assert.notOk restoreCalled
+      done()
+    @Turbolinks.enableTransitionCache()
+    @Turbolinks.visit('iframe.html', change: 'div')
+
   test "history.back() cache hit", (done) ->
     @$('#permanent').addEventListener 'click', -> done()
     change = 0


### PR DESCRIPTION
Fixes #547 