### PR TITLE
Disables Turbolinks in unsupported browsers

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -608,7 +608,7 @@ initializeTurbolinks = ->
   window.addEventListener 'hashchange', rememberCurrentUrlAndState, false
   window.addEventListener 'popstate', onHistoryChange, false
 
-browserSupportsPushState = window.history and 'pushState' of window.history
+browserSupportsPushState = window.history and 'pushState' of window.history and 'state' of window.history
 
 # Copied from https://github.com/Modernizr/Modernizr/blob/master/feature-detects/history.js
 ua = navigator.userAgent


### PR DESCRIPTION
Safari 5 supports history.pushState but not history.state. Turbolinks uses both history.pushState and history.state, but only checks for history.pushState.

Checking for `state` on `history` avoids a js error when changing pages in Safari 5 (which doesn't implement history.state). 