### PR TITLE
Fix page caching and lifecycle events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,11 @@
 
     *Kristian Plettenberg-Dussault*, *Thibaut Courouble*, *David Heinemeier Hansson*
 
-*   Add a `page:after-remove` event, triggered after a node (stored in `event.data`) is removed from the DOM, to give user scripts the opportunity to clean up references to these nodes and avoid memory leaks.
+*   Trigger `page:partial-load` instead `page:load` on partial replacement (`Turbolinks.visit()` or `Turbolinks.replace()` with `change` option)
+
+    *Thibaut Courouble*
+
+*   Add a `page:after-remove` event, triggered after an element (stored in `event.data`) is removed from the DOM (partial replacement), or a body element is evicted from the cache, to give user scripts the opportunity to clean up references to these elements and avoid memory leaks.
 
     This event replaces the `page:expire` event for cleaning up cached pages.
 
@@ -150,7 +154,7 @@
     Turbolinks.visit url, scroll: false
     ```
 
-*   Attach affected nodes to the `page:before-unload`, `page:change` and `page:load` events (in `event.data`).
+*   Attach affected elements to the `page:before-unload`, `page:change`, `page:load` and `page:partial-load` events (in `event.data`).
 
     *Thibaut Courouble*
 

--- a/test/javascript/iframe3.html
+++ b/test/javascript/iframe3.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>title 3</title>
+  <meta content="authenticity_token" name="csrf-param">
+  <meta content="token3" name="csrf-token">
+  <script src="/js/jquery.js"></script>
+  <script src="/js/turbolinks.js"></script>
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
Fix #551.

Partial replacement broke the page cache by caching `body.outerHTML` (losing all DOM state in the process) instead of the body element itself.

This PR brings back the old behavior, with the following drawback: when a partial replacement is performed, instead of caching the current page, 1) we don't cache it and 2) we remove it from the cache if it was there already (previous visit), since 1) the body element will not change and there is no simple way for us to bring back the changed nodes, 2) we don't want to restore an outdated version of the page.

Also:

- `page:after-remove` on body elements now triggers on cache eviction (since we don't want to lose DOM state when restoring pages from the cache)
- to avoid triggering `page:load` on the same body element more than once, which would be a major breaking change, partial replacements now trigger the `page:partial-load` event.

@dhh @reed @kristianpd @WojtekKruszewski 