### PR TITLE
Fix Turbolinks.visit()

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -639,7 +639,7 @@ if browserSupportsTurbolinks
   visit = fetch
   initializeTurbolinks()
 else
-  visit = (url) -> document.location.href = url
+  visit = (url = document.location.href) -> document.location.href = url
 
 # Public API
 #   Turbolinks.visit(url)


### PR DESCRIPTION
If the browser doesn't support Turbolinks, when `Turbolinks.visit()` was
being called with no parameters `document.location.href = undefined` was
executed, resulting in a request to a non-existent route.

This is not happening if the browser does support Turbolinks.

This commit fixes this issue.