### PR TITLE
Scripts within permanent nodes tweak

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -203,9 +203,17 @@ onNodeRemoved = (node) ->
     jQuery(node).remove()
   triggerEvent(EVENTS.AFTER_REMOVE, node)
 
+withinPermanent = (element) ->
+  while element?
+    return true if element.hasAttribute && element.hasAttribute('data-turbolinks-permanent')
+    element = element.parentNode
+
+  return false
+
 executeScriptTags = (selector) ->
   scripts = document.body.querySelectorAll(selector)
   for script in scripts when script.type in ['', 'text/javascript']
+    continue if withinPermanent(script)
     copy = document.createElement 'script'
     copy.setAttribute attr.name, attr.value for attr in script.attributes
     copy.async = false unless script.hasAttribute 'async'

--- a/test/javascript/iframe.html
+++ b/test/javascript/iframe.html
@@ -17,6 +17,7 @@
   <div id="change">change content</div>
   <div id="change:key">change content</div>
   <div id="permanent" data-turbolinks-permanent>permanent content</div>
+  <div id="permanent-script" data-turbolinks-permanent><script>window.countPerm = (window.countPerm || 0) + 1;</script></div>
   <div id="temporary" data-turbolinks-temporary>temporary content</div>
   <script>window.i = window.i || 0; window.i++;</script>
   <script data-turbolinks-eval="always">window.k = window.k || 0; window.k++;</script>

--- a/test/javascript/turbolinks_replace_test.coffee
+++ b/test/javascript/turbolinks_replace_test.coffee
@@ -376,3 +376,23 @@ suite 'Turbolinks.replace()', ->
       assert.equal @window.count, 1 # using importNode before swapping the nodes would double-eval scripts in Chrome/Safari
       done()
     @Turbolinks.replace(doc, change: ['change'])
+
+  test "doesn't run scripts inside :permanent nodes", (done) ->
+    doc = """
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <title>title</title>
+      </head>
+      <body>
+        <div id="change">
+          new content
+        </div>
+      </body>
+      </html>
+    """
+    @document.addEventListener 'page:partial-load', =>
+      assert.equal @window.countPerm, 1
+      done()
+    @Turbolinks.replace(doc, change: ['change'])
+


### PR DESCRIPTION
Checks a script's parent nodes to ensure it's not within a data-turbolinks-permanent before running it. Related to issue #599 that I created.