### PR TITLE
Script eval within permanent nodes

### DIFF
--- a/test/javascript/iframe.html
+++ b/test/javascript/iframe.html
@@ -17,6 +17,10 @@
   <div id="change">change content</div>
   <div id="change:key">change content</div>
   <div id="permanent" data-turbolinks-permanent>permanent content</div>
+  <div id="permanent-script" data-turbolinks-permanent>
+    <script>window.countPerm = (window.countPerm || 0) + 1;</script>
+    <script data-turbolinks-eval="always">window.countAlways = (window.countAlways || 0) + 1;</script>
+  </div>
   <div id="temporary" data-turbolinks-temporary>temporary content</div>
   <script>window.i = window.i || 0; window.i++;</script>
   <script data-turbolinks-eval="always">window.k = window.k || 0; window.k++;</script>

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -54,6 +54,8 @@ suite 'Turbolinks.visit()', ->
       assert.deepEqual event.data, [@document.body]
       assert.equal @window.i, 1
       assert.equal @window.j, 1
+      assert.equal @window.countPerm, 1
+      assert.equal @window.countAlways, 1
       assert.isUndefined @window.headScript
       assert.isUndefined @window.bodyScriptEvalFalse
       assert.ok @$('#new-div')
@@ -105,6 +107,8 @@ suite 'Turbolinks.visit()', ->
       assert.equal afterRemoveNodes.length, 0 # after-remove is called immediately on changed nodes
       assert.deepEqual event.data, [@$('#temporary'), @$('#change'), @$('[id="change:key"]')]
       assert.equal @window.i, 2
+      assert.equal @window.countPerm, 1
+      assert.equal @window.countAlways, 2
       assert.isUndefined @window.j
       assert.isUndefined @window.headScript
       assert.isUndefined @window.bodyScriptEvalFalse


### PR DESCRIPTION
This PR checks to see if a script tag exists within a `data-turbolinks-permanent` node and skipping its execution if so. This could also be solved by documenting the behavior of scripts in permanent nodes and mentioning it can be avoided by adding `data-turbolinks-eval="false"`.

Also adds a test to demonstrate the behavior.

Related to #599 that I created and somewhat related to #546.

(fix #599)