### PR TITLE
Add bower support.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "turbolinks",
+  "version": "2.5.2",
+  "homepage": "https://github.com/rails/turbolinks",
+  "authors": [
+    "Chris Wanstrath",
+    "Sam Stephenson",
+    "Josh Peek"
+  ],
+  "description": "Turbolinks makes following links in your web application faster (use with Rails Asset Pipeline)",
+  "main": "lib/assets/javascripts/turbolinks.js.coffee",
+  "keywords": [
+    "turbolinks",
+    "rails"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Backstory: A decent subset of folks (myself included) use bower to manage frontend dependencies in Rails apps. GitHub user @menglr was formerly maintaining a bower package for Turbolinks based on a fork of the main repo but they have recently deleted their GitHub account causing the package to break. I was able to [get the turbolinks package name released](https://github.com/bower/registry/issues/145) and was wondering if it would be possible to just add bower support to the main repository rather than starting another forked repo for the package. 