### PR TITLE
Delay before showing progress bar

### DIFF
--- a/lib/assets/javascripts/turbolinks.coffee
+++ b/lib/assets/javascripts/turbolinks.coffee
@@ -486,6 +486,7 @@ class ProgressBar
     @value = 0
     @content = ''
     @speed = 300
+    @delay = 400
     @opacity = originalOpacity
     @install()
 
@@ -505,7 +506,11 @@ class ProgressBar
       @_reset()
       @_reflow()
 
+    @startTime = Date.now()
     @advanceTo(5)
+
+  delayComplete: ->
+    Date.now() - @startTime > @delay
 
   advanceTo: (value) ->
     if value > @value <= 100
@@ -564,6 +569,7 @@ class ProgressBar
     result
 
   _updateStyle: (forceRepaint = false) ->
+    return unless @delayComplete() || forceRepaint
     @_changeContentToForceRepaint() if forceRepaint
     @styleElement.textContent = @_createCSSRule()
 


### PR DESCRIPTION
The progress bar makes loading feel slower for fast requests as @javan noted in #581.

This PR makes `_updateStyle` a no-op until a set delay has passed (default 400ms).

There is another implementation in #593 but it only delays the initial `advanceTo` call, not subsequent ones.