### PR TITLE
Ignore non ActionController::Base classes

### DIFF
--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -27,6 +27,8 @@ module Turbolinks
 
     initializer :turbolinks do |app|
       ActiveSupport.on_load(:action_controller) do
+        next if self != ActionController::Base
+
         if app.config.turbolinks.auto_include
           include Controller
         end


### PR DESCRIPTION
By adding this line we guarantee that the rails Engine won't include turbolinks modules into non regular controllers, such as `ActionController::API` (which happens to not support cookies).

Including `Turbolinks` into `ActionController`s that don't support cookies would cause requests to error out.

ps: This could also be solved by just adding a `respond_to?(:cookies)` inside `Turbolinks::Cookies#set_request_method_cookie`, but I believe my solution is a little cleaner.

ps2: I can't really think of a decent way to write a test for this.