### PR TITLE
Ensures that only script tags contained within changed nodes are executed on partial page replacement

### DIFF
--- a/lib/assets/javascripts/turbolinks.coffee
+++ b/lib/assets/javascripts/turbolinks.coffee
@@ -170,7 +170,7 @@ changePage = (title, body, csrfToken, options) ->
     setAutofocusElement()
     changedNodes = [body]
 
-  executeScriptTags(getScriptsToRun(options.runScripts))
+  executeScriptTags(getScriptsToRun(changedNodes, options.runScripts))
   currentState = window.history.state
 
   triggerEvent EVENTS.CHANGE, changedNodes
@@ -209,9 +209,9 @@ onNodeRemoved = (node) ->
     jQuery(node).remove()
   triggerEvent(EVENTS.AFTER_REMOVE, node)
 
-getScriptsToRun = (runScripts) ->
+getScriptsToRun = (changedNodes, runScripts) ->
   selector = if runScripts is false then 'script[data-turbolinks-eval="always"]' else 'script:not([data-turbolinks-eval="false"])'
-  script for script in document.body.querySelectorAll(selector) when isEvalAlways(script) or not withinPermanent(script)
+  script for script in document.body.querySelectorAll(selector) when isEvalAlways(script) or (nestedWithinNodeList(changedNodes, script) and not withinPermanent(script))
 
 isEvalAlways = (script) ->
   script.getAttribute('data-turbolinks-eval') is 'always'
@@ -219,6 +219,13 @@ isEvalAlways = (script) ->
 withinPermanent = (element) ->
   while element?
     return true if element.hasAttribute?('data-turbolinks-permanent')
+    element = element.parentNode
+
+  return false
+
+nestedWithinNodeList = (nodeList, element) ->
+  while element?
+    return true if element in nodeList
     element = element.parentNode
 
   return false

--- a/test/javascript/turbolinks_replace_test.coffee
+++ b/test/javascript/turbolinks_replace_test.coffee
@@ -168,7 +168,7 @@ suite 'Turbolinks.replace()', ->
       assert.ok beforeUnloadFired
       assert.equal afterRemoveNodes.length, 0
       assert.deepEqual event.data, [@$('#temporary'), @$('#change'), @$('[id="change:key"]')]
-      assert.equal @window.i, 2 # scripts are re-run
+      assert.equal @window.i, 1 # only scripts within the changed nodes are re-run
       assert.isUndefined @window.bodyScript
       assert.isUndefined @window.headScript
       assert.notOk @$('#new-div')
@@ -205,7 +205,7 @@ suite 'Turbolinks.replace()', ->
       assert.equal event.data, afterRemoveNodes.shift()
     @document.addEventListener 'page:change', =>
       assert.equal afterRemoveNodes.length, 0
-      assert.equal @window.i, 2 # scripts are re-run
+      assert.equal @window.i, 1 # only scripts within the changed nodes are re-run
       assert.isUndefined @window.outsideScript
       assert.equal @window.insideScript, true
       assert.notOk @$('#new-div')

--- a/test/javascript/turbolinks_visit_test.coffee
+++ b/test/javascript/turbolinks_visit_test.coffee
@@ -109,7 +109,7 @@ suite 'Turbolinks.visit()', ->
       assert.ok pageChangeFired
       assert.equal afterRemoveNodes.length, 0 # after-remove is called immediately on changed nodes
       assert.deepEqual event.data, [@$('#temporary'), @$('#change'), @$('[id="change:key"]')]
-      assert.equal @window.i, 2
+      assert.equal @window.i, 1 # only scripts within the changed nodes are re-run
       assert.equal @window.countPerm, 1
       assert.equal @window.countAlways, 2
       assert.isUndefined @window.j


### PR DESCRIPTION
This fixes the issue I opened earlier, #617. It appears that it may also address #546.