### PR TITLE
Use session cookies instead

### DIFF
--- a/lib/assets/javascripts/turbolinks.coffee
+++ b/lib/assets/javascripts/turbolinks.coffee
@@ -318,7 +318,7 @@ removeDuplicates = (array) ->
 
 popCookie = (name) ->
   value = document.cookie.match(new RegExp(name+"=(\\w+)"))?[1].toUpperCase() or ''
-  document.cookie = name + '=; expires=Thu, 01-Jan-70 00:00:01 GMT; path=/'
+  document.cookie = name + '=; path=/'
   value
 
 uniqueId = ->


### PR DESCRIPTION
By default all cookies generated in turbolinks via javascript are
generated with no expiration date. It would be better to use session
cookies.

Related to ISSUE #641 

The reason why I think is better to have a session cookie is beacause of [the european cookies law](http://ec.europa.eu/ipg/basics/legal/cookies/index_en.htm) in Europe only 
first‑party session cookies DO NOT require informed consent.